### PR TITLE
fix(security): redact sensitive credentials in configuration output

### DIFF
--- a/cmd/gitlab-backup.go
+++ b/cmd/gitlab-backup.go
@@ -41,7 +41,7 @@ func printConfiguration() {
 
 	fmt.Println("--------------------------------------------------")
 	fmt.Println("Gitlab-backup configuration:")
-	fmt.Printf("%+v\n", c)
+	fmt.Print(c.Redacted())
 	os.Exit(0)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const redactedValue = "***REDACTED***"
+
 // S3Config holds the configuration for S3 storage backend.
 type S3Config struct {
 	Endpoint   string `env:"S3ENDPOINT"            env-default:""   yaml:"endpoint"`
@@ -72,6 +74,25 @@ func (c *Config) IsConfigValid() bool {
 
 func (c *Config) String() string {
 	cyaml, err := yaml.Marshal(c)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	}
+	return string(cyaml)
+}
+
+// Redacted returns a YAML representation of the config with sensitive fields redacted.
+func (c *Config) Redacted() string {
+	redacted := *c
+	if redacted.GitlabToken != "" {
+		redacted.GitlabToken = redactedValue
+	}
+	if redacted.S3cfg.AccessKey != "" {
+		redacted.S3cfg.AccessKey = redactedValue
+	}
+	if redacted.S3cfg.SecretKey != "" {
+		redacted.S3cfg.SecretKey = redactedValue
+	}
+	cyaml, err := yaml.Marshal(redacted)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 	}


### PR DESCRIPTION
Implement credential redaction for the -cfg flag to prevent sensitive
information exposure when printing configuration.

Changes:
- Add Redacted() method to Config struct that redacts GitLab tokens
  and AWS credentials (access key, secret key)
- Update printConfiguration() to use Redacted() instead of raw output
- Add comprehensive tests for redaction functionality including
  edge cases for empty secrets

This addresses CWE-532 (Insertion of Sensitive Information into Log)
and prevents credentials from being exposed in terminal history,
screenshots, CI/CD logs, or shared terminal sessions.

Closes #280