### PR TITLE
fix(storage): add archive validation to ExtractArchive

### DIFF
--- a/pkg/storage/archive.go
+++ b/pkg/storage/archive.go
@@ -47,6 +47,11 @@ type ArchiveContents struct {
 // Returns ArchiveContents with the archive path.
 // The ctx parameter is kept for API compatibility but not currently used.
 func ExtractArchive(_ context.Context, archivePath string, destDir string) (*ArchiveContents, error) {
+	// Validate archive format first
+	if err := ValidateArchive(archivePath); err != nil {
+		return nil, fmt.Errorf("invalid archive format: %w", err)
+	}
+
 	// All archives are direct GitLab exports - no extraction needed
 	return &ArchiveContents{
 		ProjectExportPath: archivePath,


### PR DESCRIPTION
Fixes #300 by adding format validation before extraction.
Invalid archives now fail early in Phase 3 (Extraction)
with clear error messages instead of cryptic GitLab import
failures in Phase 4 (Import).

Changes:
- Call ValidateArchive() at start of ExtractArchive()
- Add comprehensive test coverage for validation errors
- Test 5 scenarios: non-existent, directory, empty, invalid gzip, corrupted tar