### PR TITLE
fix(context): add proper context propagation throughout codebase

### DIFF
--- a/cmd/gitlab-backup/gitlab-backup.go
+++ b/cmd/gitlab-backup/gitlab-backup.go
@@ -188,8 +188,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Create context for app initialization and execution
+	ctx := context.Background()
+
 	// Initialize app
-	app, err := app.NewApp(cfg)
+	app, err := app.NewApp(ctx, cfg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
@@ -197,7 +200,6 @@ func main() {
 
 	l := initTrace(os.Getenv("DEBUGLEVEL"), cfg.NoLogTime)
 	app.SetLogger(l)
-	ctx := context.Background()
 	err = app.Run(ctx)
 
 	if err != nil {

--- a/cmd/gitlab-restore/gitlab-restore.go
+++ b/cmd/gitlab-restore/gitlab-restore.go
@@ -79,7 +79,7 @@ func main() {
 	gitlabClient.SetGitlabEndpoint(cfg.GitlabURI)
 
 	// Initialize storage
-	storage, err := initializeStorage(cfg)
+	storage, err := initializeStorage(ctx, cfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing storage: %v\n", redactCredentials(err.Error(), cfg))
 		os.Exit(1)
@@ -167,11 +167,12 @@ func validateAndLoadConfig(configFile, archive, namespace, project string, overw
 }
 
 // initializeStorage creates the appropriate storage backend.
+// The context is used for S3 client initialization and may respect timeout/cancellation.
 //nolint:ireturn // Returning interface is intentional for abstraction
-func initializeStorage(cfg *config.Config) (restore.Storage, error) {
+func initializeStorage(ctx context.Context, cfg *config.Config) (restore.Storage, error) {
 	if cfg.StorageType == "s3" {
 		//nolint:lll // Function call with multiple parameters
-		s3Store, err := s3storage.NewS3Storage(cfg.S3cfg.Region, cfg.S3cfg.Endpoint, cfg.S3cfg.BucketName, cfg.S3cfg.BucketPath)
+		s3Store, err := s3storage.NewS3Storage(ctx, cfg.S3cfg.Region, cfg.S3cfg.Endpoint, cfg.S3cfg.BucketName, cfg.S3cfg.BucketPath)
 		if err != nil {
 			return nil, fmt.Errorf("initializing S3 storage: %w", err)
 		}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -43,7 +43,8 @@ type Logger interface {
 }
 
 // NewApp returns a new App struct.
-func NewApp(cfg *config.Config) (*App, error) {
+// The context is used for S3 client initialization and may respect timeout/cancellation.
+func NewApp(ctx context.Context, cfg *config.Config) (*App, error) {
 	var err error
 	app := &App{
 		cfg:           cfg,
@@ -53,6 +54,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 	gitlab.SetLogger(app.log)
 	if cfg.IsS3ConfigValid() {
 		app.storage, err = s3storage.NewS3Storage(
+			ctx,
 			cfg.S3cfg.Region,
 			cfg.S3cfg.Endpoint,
 			cfg.S3cfg.BucketName,

--- a/pkg/storage/archive.go
+++ b/pkg/storage/archive.go
@@ -45,8 +45,13 @@ type ArchiveContents struct {
 // All archives created by gitlab-backup are direct GitLab exports and require no extraction.
 //
 // Returns ArchiveContents with the archive path.
-// The ctx parameter is kept for API compatibility but not currently used.
-func ExtractArchive(_ context.Context, archivePath string, destDir string) (*ArchiveContents, error) {
+// The context is checked for cancellation before validation for consistency with other operations.
+func ExtractArchive(ctx context.Context, archivePath string, destDir string) (*ArchiveContents, error) {
+	// Check cancellation before validation
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("operation cancelled: %w", ctx.Err())
+	}
+
 	// Validate archive format first
 	if err := ValidateArchive(archivePath); err != nil {
 		return nil, fmt.Errorf("invalid archive format: %w", err)

--- a/pkg/storage/s3storage/s3storage.go
+++ b/pkg/storage/s3storage/s3storage.go
@@ -28,7 +28,8 @@ type S3Storage struct {
 }
 
 // NewS3Storage creates a new S3Storage.
-func NewS3Storage(region string, endpoint string, bucket string, path string) (*S3Storage, error) {
+// The context is used for AWS SDK configuration loading and may respect timeout/cancellation.
+func NewS3Storage(ctx context.Context, region string, endpoint string, bucket string, path string) (*S3Storage, error) {
 	var err error
 
 	s := &S3Storage{
@@ -37,15 +38,15 @@ func NewS3Storage(region string, endpoint string, bucket string, path string) (*
 		bucket:   bucket,
 		path:     path,
 	}
-	err = s.InitClient()
+	err = s.initClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return s, nil
 }
 
-// InitClient initializes the s3 client.
-func (s *S3Storage) InitClient() error {
+// initClient initializes the s3 client with context support.
+func (s *S3Storage) initClient(ctx context.Context) error {
 	if os.Getenv("AWS_ACCESS_KEY_ID") != "" {
 		//nolint:staticcheck // SA1019: Using deprecated AWS endpoint resolver for compatibility
 		staticResolver := aws.EndpointResolverFunc(func(_, _ string) (aws.Endpoint, error) {
@@ -81,7 +82,7 @@ func (s *S3Storage) InitClient() error {
 	// 	return
 	// }
 
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(s.region))
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(s.region))
 	if err != nil {
 		return fmt.Errorf("failed to load AWS config: %w", err)
 	}


### PR DESCRIPTION
- Add context parameter to NewS3Storage and NewApp (breaking change)
- Replace context.TODO() with passed context in S3 client initialization
- Propagate context to GitLab API calls in validator with cancellation checks
- Add context support to import status polling and file import
- Implement context-aware file copy in LocalStorage with partial file cleanup
- Add context check to ExtractArchive for consistency
- Add context cancellation tests for S3Storage and LocalStorage

This enables proper timeout handling, cancellation support (Ctrl+C), and
request tracing throughout the application.

Fixes #308

BREAKING CHANGE: NewS3Storage() now requires context.Context as first parameter