### PR TITLE
fix: improve error handling and context throughout codebase

### DIFF
--- a/cmd/gitlab-restore/gitlab-restore.go
+++ b/cmd/gitlab-restore/gitlab-restore.go
@@ -218,7 +218,11 @@ func (a *s3StorageAdapter) Get(ctx context.Context, key string) (string, error) 
 		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
 	defer func() {
-		_ = tempFile.Close()
+		if closeErr := tempFile.Close(); closeErr != nil {
+			// Log but don't fail - file is already downloaded successfully
+			fmt.Fprintf(os.Stderr, "Warning: failed to close temp file %s: %v\n",
+				tempFile.Name(), closeErr)
+		}
 	}()
 
 	// Use S3Storage's GetFile method

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -176,7 +176,7 @@ func (a *App) ExportGroup(ctx context.Context) error {
 	}
 	err = eg.Wait()
 	if err != nil {
-		return ErrBackupErrors
+		return fmt.Errorf("%w for group %d: %w", ErrBackupErrors, a.cfg.GitlabGroupID, err)
 	}
 	return nil
 }

--- a/pkg/app/restore/validator.go
+++ b/pkg/app/restore/validator.go
@@ -67,7 +67,8 @@ func (v *Validator) ValidateProjectEmpty(ctx context.Context, projectID int64) (
 func (v *Validator) checkCommits(ctx context.Context, projectID int64) (bool, int, error) {
 	// Early exit if context cancelled
 	if ctx.Err() != nil {
-		return false, 0, fmt.Errorf("validation cancelled: %w", ctx.Err())
+		return false, 0, fmt.Errorf("validation cancelled while checking commits for project %d: %w",
+			projectID, ctx.Err())
 	}
 
 	commits, resp, err := v.commitsService.ListCommits(
@@ -82,9 +83,10 @@ func (v *Validator) checkCommits(ctx context.Context, projectID int64) (bool, in
 	)
 	if err != nil {
 		if ctx.Err() != nil {
-			return false, 0, fmt.Errorf("validation cancelled: %w", ctx.Err())
+			return false, 0, fmt.Errorf("validation cancelled while checking commits for project %d: %w",
+				projectID, ctx.Err())
 		}
-		return false, 0, fmt.Errorf("failed to list commits: %w", err)
+		return false, 0, fmt.Errorf("failed to list commits for project %d: %w", projectID, err)
 	}
 
 	return len(commits) > 0, getTotalCount(resp, len(commits)), nil
@@ -95,7 +97,8 @@ func (v *Validator) checkCommits(ctx context.Context, projectID int64) (bool, in
 func (v *Validator) checkIssues(ctx context.Context, projectID int64) (bool, int, error) {
 	// Early exit if context cancelled
 	if ctx.Err() != nil {
-		return false, 0, fmt.Errorf("validation cancelled: %w", ctx.Err())
+		return false, 0, fmt.Errorf("validation cancelled while checking issues for project %d: %w",
+			projectID, ctx.Err())
 	}
 
 	issues, resp, err := v.issuesService.ListProjectIssues(
@@ -110,9 +113,10 @@ func (v *Validator) checkIssues(ctx context.Context, projectID int64) (bool, int
 	)
 	if err != nil {
 		if ctx.Err() != nil {
-			return false, 0, fmt.Errorf("validation cancelled: %w", ctx.Err())
+			return false, 0, fmt.Errorf("validation cancelled while checking issues for project %d: %w",
+				projectID, ctx.Err())
 		}
-		return false, 0, fmt.Errorf("failed to list issues: %w", err)
+		return false, 0, fmt.Errorf("failed to list issues for project %d: %w", projectID, err)
 	}
 
 	return len(issues) > 0, getTotalCount(resp, len(issues)), nil
@@ -123,7 +127,8 @@ func (v *Validator) checkIssues(ctx context.Context, projectID int64) (bool, int
 func (v *Validator) checkLabels(ctx context.Context, projectID int64) (bool, int, error) {
 	// Early exit if context cancelled
 	if ctx.Err() != nil {
-		return false, 0, fmt.Errorf("validation cancelled: %w", ctx.Err())
+		return false, 0, fmt.Errorf("validation cancelled while checking labels for project %d: %w",
+			projectID, ctx.Err())
 	}
 
 	labels, resp, err := v.labelsService.ListLabels(
@@ -138,9 +143,10 @@ func (v *Validator) checkLabels(ctx context.Context, projectID int64) (bool, int
 	)
 	if err != nil {
 		if ctx.Err() != nil {
-			return false, 0, fmt.Errorf("validation cancelled: %w", ctx.Err())
+			return false, 0, fmt.Errorf("validation cancelled while checking labels for project %d: %w",
+				projectID, ctx.Err())
 		}
-		return false, 0, fmt.Errorf("failed to list labels: %w", err)
+		return false, 0, fmt.Errorf("failed to list labels for project %d: %w", projectID, err)
 	}
 
 	return len(labels) > 0, getTotalCount(resp, len(labels)), nil

--- a/pkg/gitlab/client_interface.go
+++ b/pkg/gitlab/client_interface.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"fmt"
 	"io"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
@@ -151,19 +152,31 @@ type groupsServiceWrapper struct {
 	service gitlab.GroupsServiceInterface
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *groupsServiceWrapper) GetGroup(gid any, opt *gitlab.GetGroupOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Group, *gitlab.Response, error) {
-	return w.service.GetGroup(gid, opt, options...)
+	group, resp, err := w.service.GetGroup(gid, opt, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to get group %v: %w", gid, err)
+	}
+	return group, resp, nil
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *groupsServiceWrapper) ListSubGroups(gid any, opt *gitlab.ListSubGroupsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Group, *gitlab.Response, error) {
-	return w.service.ListSubGroups(gid, opt, options...)
+	groups, resp, err := w.service.ListSubGroups(gid, opt, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to list subgroups for group %v: %w", gid, err)
+	}
+	return groups, resp, nil
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *groupsServiceWrapper) ListGroupProjects(gid any, opt *gitlab.ListGroupProjectsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Project, *gitlab.Response, error) {
-	return w.service.ListGroupProjects(gid, opt, options...)
+	projects, resp, err := w.service.ListGroupProjects(gid, opt, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to list projects for group %v: %w", gid, err)
+	}
+	return projects, resp, nil
 }
 
 // projectsServiceWrapper wraps the official GitLab projects service.
@@ -171,9 +184,13 @@ type projectsServiceWrapper struct {
 	service gitlab.ProjectsServiceInterface
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *projectsServiceWrapper) GetProject(pid any, opt *gitlab.GetProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Project, *gitlab.Response, error) {
-	return w.service.GetProject(pid, opt, options...)
+	project, resp, err := w.service.GetProject(pid, opt, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to get project %v: %w", pid, err)
+	}
+	return project, resp, nil
 }
 
 // projectImportExportServiceWrapper wraps the official GitLab project import/export service.
@@ -181,29 +198,70 @@ type projectImportExportServiceWrapper struct {
 	service gitlab.ProjectImportExportServiceInterface
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *projectImportExportServiceWrapper) ScheduleExport(pid any, opt *gitlab.ScheduleExportOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error) {
-	return w.service.ScheduleExport(pid, opt, options...)
+	resp, err := w.service.ScheduleExport(pid, opt, options...)
+	if err != nil {
+		return resp, fmt.Errorf("failed to schedule export for project %v: %w", pid, err)
+	}
+	return resp, nil
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *projectImportExportServiceWrapper) ExportStatus(pid any, options ...gitlab.RequestOptionFunc) (*gitlab.ExportStatus, *gitlab.Response, error) {
-	return w.service.ExportStatus(pid, options...)
+	status, resp, err := w.service.ExportStatus(pid, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to get export status for project %v: %w", pid, err)
+	}
+	return status, resp, nil
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *projectImportExportServiceWrapper) ExportDownload(pid any, options ...gitlab.RequestOptionFunc) ([]byte, *gitlab.Response, error) {
-	return w.service.ExportDownload(pid, options...)
+	data, resp, err := w.service.ExportDownload(pid, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to download export for project %v: %w", pid, err)
+	}
+	return data, resp, nil
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *projectImportExportServiceWrapper) ImportFromFile(archive io.Reader, opt *gitlab.ImportFileOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ImportStatus, *gitlab.Response, error) {
-	return w.service.ImportFromFile(archive, opt, options...)
+	status, resp, err := w.service.ImportFromFile(archive, opt, options...)
+	if err != nil {
+		path, namespace := extractImportOptions(opt)
+		return nil, resp, fmt.Errorf("failed to import project from file (path: %s, namespace: %s): %w",
+			path, namespace, err)
+	}
+	return status, resp, nil
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+// extractImportOptions extracts path and namespace from ImportFileOptions.
+func extractImportOptions(opt *gitlab.ImportFileOptions) (string, string) {
+	path := "<nil>"
+	namespace := "<nil>"
+
+	if opt == nil {
+		return path, namespace
+	}
+
+	if opt.Path != nil {
+		path = *opt.Path
+	}
+	if opt.Namespace != nil {
+		namespace = *opt.Namespace
+	}
+
+	return path, namespace
+}
+
+//nolint:lll // Wrapper method with long signature
 func (w *projectImportExportServiceWrapper) ImportStatus(pid any, options ...gitlab.RequestOptionFunc) (*gitlab.ImportStatus, *gitlab.Response, error) {
-	return w.service.ImportStatus(pid, options...)
+	status, resp, err := w.service.ImportStatus(pid, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to get import status for project %v: %w", pid, err)
+	}
+	return status, resp, nil
 }
 
 // labelsServiceWrapper wraps the official GitLab labels service.
@@ -211,14 +269,22 @@ type labelsServiceWrapper struct {
 	service gitlab.LabelsServiceInterface
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *labelsServiceWrapper) ListLabels(pid any, opt *gitlab.ListLabelsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Label, *gitlab.Response, error) {
-	return w.service.ListLabels(pid, opt, options...)
+	labels, resp, err := w.service.ListLabels(pid, opt, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to list labels for project %v: %w", pid, err)
+	}
+	return labels, resp, nil
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *labelsServiceWrapper) CreateLabel(pid any, opt *gitlab.CreateLabelOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Label, *gitlab.Response, error) {
-	return w.service.CreateLabel(pid, opt, options...)
+	label, resp, err := w.service.CreateLabel(pid, opt, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to create label for project %v: %w", pid, err)
+	}
+	return label, resp, nil
 }
 
 // issuesServiceWrapper wraps the official GitLab issues service.
@@ -226,19 +292,31 @@ type issuesServiceWrapper struct {
 	service gitlab.IssuesServiceInterface
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *issuesServiceWrapper) ListProjectIssues(pid any, opt *gitlab.ListProjectIssuesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Issue, *gitlab.Response, error) {
-	return w.service.ListProjectIssues(pid, opt, options...)
+	issues, resp, err := w.service.ListProjectIssues(pid, opt, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to list issues for project %v: %w", pid, err)
+	}
+	return issues, resp, nil
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *issuesServiceWrapper) CreateIssue(pid any, opt *gitlab.CreateIssueOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Issue, *gitlab.Response, error) {
-	return w.service.CreateIssue(pid, opt, options...)
+	issue, resp, err := w.service.CreateIssue(pid, opt, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to create issue for project %v: %w", pid, err)
+	}
+	return issue, resp, nil
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *issuesServiceWrapper) UpdateIssue(pid any, issue int64, opt *gitlab.UpdateIssueOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Issue, *gitlab.Response, error) {
-	return w.service.UpdateIssue(pid, issue, opt, options...)
+	updatedIssue, resp, err := w.service.UpdateIssue(pid, issue, opt, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to update issue %d for project %v: %w", issue, pid, err)
+	}
+	return updatedIssue, resp, nil
 }
 
 // notesServiceWrapper wraps the official GitLab notes service.
@@ -246,9 +324,13 @@ type notesServiceWrapper struct {
 	service gitlab.NotesServiceInterface
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *notesServiceWrapper) CreateIssueNote(pid any, issue int64, opt *gitlab.CreateIssueNoteOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Note, *gitlab.Response, error) {
-	return w.service.CreateIssueNote(pid, issue, opt, options...)
+	note, resp, err := w.service.CreateIssueNote(pid, issue, opt, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to create note for issue %d in project %v: %w", issue, pid, err)
+	}
+	return note, resp, nil
 }
 
 // commitsServiceWrapper wraps the official GitLab commits service.
@@ -256,7 +338,11 @@ type commitsServiceWrapper struct {
 	service gitlab.CommitsServiceInterface
 }
 
-//nolint:lll,wrapcheck // Wrapper method with long signature, error passthrough intentional
+//nolint:lll // Wrapper method with long signature
 func (w *commitsServiceWrapper) ListCommits(pid any, opt *gitlab.ListCommitsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Commit, *gitlab.Response, error) {
-	return w.service.ListCommits(pid, opt, options...)
+	commits, resp, err := w.service.ListCommits(pid, opt, options...)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to list commits for project %v: %w", pid, err)
+	}
+	return commits, resp, nil
 }

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -212,7 +212,8 @@ func NewGitlabServiceWithTimeout(timeoutMins int) *Service {
 	token := os.Getenv("GITLAB_TOKEN")
 	glClient, err := gitlab.NewClient(token)
 	if err != nil {
-		log.Error("failed to create GitLab client", "error", err)
+		log.Error("failed to create GitLab client - check GITLAB_TOKEN environment variable",
+			"error", err, "has_token", token != "")
 		return nil
 	}
 
@@ -257,7 +258,8 @@ func (r *Service) SetGitlabEndpoint(gitlabAPIEndpoint string) {
 	// Create a new client with the custom base URL
 	glClient, err := gitlab.NewClient(r.token, gitlab.WithBaseURL(gitlabAPIEndpoint))
 	if err != nil {
-		log.Error("failed to create GitLab client with custom base URL", "error", err, "url", gitlabAPIEndpoint)
+		log.Error("failed to create GitLab client with custom base URL - check endpoint and token",
+			"error", err, "url", gitlabAPIEndpoint, "has_token", r.token != "")
 		return
 	}
 	r.client = NewGitLabClientWrapper(glClient)
@@ -282,7 +284,8 @@ func (r *Service) SetToken(token string) {
 		glClient, err = gitlab.NewClient(token)
 	}
 	if err != nil {
-		log.Error("failed to create GitLab client with new token", "error", err)
+		log.Error("failed to create GitLab client with new token - check token validity",
+			"error", err, "endpoint", r.gitlabAPIEndpoint, "has_token", token != "")
 		return
 	}
 	r.client = NewGitLabClientWrapper(glClient)

--- a/pkg/gitlab/group.go
+++ b/pkg/gitlab/group.go
@@ -30,7 +30,7 @@ func (s *Service) GetSubgroups(ctx context.Context, groupID int64) ([]Group, err
 	for {
 		subgroups, resp, err := s.client.Groups().ListSubGroups(groupID, opt, gitlab.WithContext(ctx))
 		if err != nil {
-			return nil, fmt.Errorf("error listing subgroups: %w", err)
+			return nil, fmt.Errorf("error listing subgroups for group %d: %w", groupID, err)
 		}
 		
 		// Convert to our Group type
@@ -85,7 +85,7 @@ func (s *Service) GetProjectsOfGroup(ctx context.Context, groupID int64) ([]Proj
 	// Get projects for the main group
 	projects, err := s.GetProjectsLst(ctx, groupID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("got error when listing projects of group %d: %w", groupID, err)
 	}
 	// Filter out archived projects from the main group as well
 	for _, project := range projects {
@@ -111,7 +111,7 @@ func (s *Service) GetProjectsLst(ctx context.Context, groupID int64) ([]Project,
 	for {
 		projects, resp, err := s.client.Groups().ListGroupProjects(groupID, opt, gitlab.WithContext(ctx))
 		if err != nil {
-			return nil, fmt.Errorf("error listing group projects: %w", err)
+			return nil, fmt.Errorf("error listing group projects for group %d: %w", groupID, err)
 		}
 		
 		// Convert to our Project type

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -51,14 +51,20 @@ func execute(command string) error {
 	if command == "" {
 		return nil
 	}
-	commandSplitter, _ := splitter.NewSplitter(' ', splitter.SingleQuotes, splitter.DoubleQuotes)
+	commandSplitter, err := splitter.NewSplitter(' ', splitter.SingleQuotes, splitter.DoubleQuotes)
+	if err != nil {
+		return fmt.Errorf("failed to create command splitter: %w", err)
+	}
 	trimmer := splitter.Trim("'\"")
-	splitCmd, _ := commandSplitter.Split(command, trimmer)
+	splitCmd, err := commandSplitter.Split(command, trimmer)
+	if err != nil {
+		return fmt.Errorf("failed to parse command '%s': %w", command, err)
+	}
 	if len(splitCmd) == 0 {
 		return nil
 	}
 	//nolint:gosec,noctx // G204: Command execution with user input is intentional for hook functionality
-	_, err := exec.Command(splitCmd[0], splitCmd[1:]...).CombinedOutput()
+	_, err = exec.Command(splitCmd[0], splitCmd[1:]...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to execute %s: %w", command, err)
 	}


### PR DESCRIPTION
- Add proper defer Close() error handling in S3 storage (SaveFile, GetFile)
- Log Close() errors in gitlab-restore instead of silently ignoring
- Add project/group IDs to all GitLab wrapper method errors (15 methods)
- Include operation context in validator error messages
- Enhance GitLab client init error messages with token/endpoint info
- Wrap ErrBackupErrors with group ID in ExportGroup
- Fix silent error suppression in hooks command parsing
- Add group IDs to group operation error messages

Improves debugging by providing clear context about which resource
(project, group, file) failed and what operation was being performed.
Critical for Windows file handle cleanup and production troubleshooting.

Fixes #306