### PR TITLE
honor gitlabURI and gitlabToken from config

### DIFF
--- a/cmd/gitlab-backup/gitlab-backup.go
+++ b/cmd/gitlab-backup/gitlab-backup.go
@@ -192,15 +192,17 @@ func main() {
 	// Create context for app initialization and execution
 	ctx := context.Background()
 
-	// Initialize app
-	app, err := app.NewApp(ctx, cfg)
+	// Build the logger first so NewApp can report any client-construction error.
+	l := initTrace(os.Getenv("DEBUGLEVEL"), cfg.NoLogTime)
+
+	// Initialize app. NewApp applies the GitLab token and endpoint from the
+	// resolved configuration, so no separate wiring is needed here.
+	app, err := app.NewApp(ctx, cfg, l)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 
-	l := initTrace(os.Getenv("DEBUGLEVEL"), cfg.NoLogTime)
-	app.SetLogger(l)
 	err = app.Run(ctx)
 
 	if err != nil {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -78,6 +78,8 @@ var (
 	ErrBackupErrors = errors.New("errors occurred during backup")
 	// ErrNotDirectory is returned when a path is not a directory.
 	ErrNotDirectory = errors.New("path is not a directory")
+	// ErrGitlabClientInit is returned when the GitLab client cannot be initialized.
+	ErrGitlabClientInit = errors.New("failed to initialize gitlab client")
 )
 
 // App represents the main application structure.
@@ -96,16 +98,36 @@ type Logger interface {
 	Info(msg string, args ...any)
 }
 
-// NewApp returns a new App struct.
+// NewApp returns a new App struct fully configured from cfg.
+//
+// The GitLab connection settings (token and endpoint) are applied from cfg here,
+// so callers cannot forget to wire them up. Without this the client would
+// silently fall back to the GITLAB_TOKEN environment variable and the default
+// https://gitlab.com endpoint, ignoring the gitlabToken/gitlabURI values from a
+// config file, the environment, or the --gitlab-url flag.
+//
+// The logger is applied before the client is built so that any client
+// construction error is reported through it; pass nil to discard logs.
 // The context is used for S3 client initialization and may respect timeout/cancellation.
-func NewApp(ctx context.Context, cfg *config.Config) (*App, error) {
+func NewApp(ctx context.Context, cfg *config.Config, log Logger) (*App, error) {
 	var err error
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	gitlab.SetLogger(log)
+
+	gitlabService := gitlab.NewGitlabServiceWithTimeout(cfg.ExportTimeoutMins)
+	if gitlabService == nil {
+		return nil, ErrGitlabClientInit
+	}
+	gitlabService.SetToken(cfg.GitlabToken)
+	gitlabService.SetGitlabEndpoint(cfg.GitlabURI)
+
 	app := &App{
 		cfg:           cfg,
-		gitlabService: gitlab.NewGitlabServiceWithTimeout(cfg.ExportTimeoutMins),
-		log:           slog.New(slog.DiscardHandler),
+		gitlabService: gitlabService,
+		log:           log,
 	}
-	gitlab.SetLogger(app.log)
 	if cfg.IsS3ConfigValid() {
 		app.storage, err = s3storage.NewS3Storage(
 			ctx,

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sgaunet/gitlab-backup/pkg/config"
+	"github.com/sgaunet/gitlab-backup/pkg/constants"
+)
+
+// TestNewApp_AppliesGitlabConfig is a regression test for the bug where the
+// backup command ignored gitlabURI/gitlabToken from the resolved config: NewApp
+// built the GitLab client with defaults only (https://gitlab.com + the
+// GITLAB_TOKEN env var). NewApp must now apply the connection settings from cfg
+// so callers cannot forget to wire them up.
+func TestNewApp_AppliesGitlabConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		LocalPath:         dir,
+		GitlabToken:       "test-token",
+		GitlabURI:         "https://gitlab.example.com/api/v4",
+		ExportTimeoutMins: constants.DefaultExportTimeoutMins,
+	}
+
+	app, err := NewApp(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("NewApp returned error: %v", err)
+	}
+	if app.gitlabService == nil {
+		t.Fatal("expected gitlabService to be initialized")
+	}
+	if got := app.gitlabService.GitlabEndpoint(); got != cfg.GitlabURI {
+		t.Errorf("expected endpoint %q to be applied from config, got %q", cfg.GitlabURI, got)
+	}
+}

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -265,6 +265,14 @@ func (r *Service) SetGitlabEndpoint(gitlabAPIEndpoint string) {
 	r.client = NewGitLabClientWrapper(glClient)
 }
 
+// GitlabEndpoint returns the currently configured Gitlab API endpoint.
+func (r *Service) GitlabEndpoint() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.gitlabAPIEndpoint
+}
+
 // SetToken sets the Gitlab API token
 // default: GITLAB_TOKEN env variable
 func (r *Service) SetToken(token string) {


### PR DESCRIPTION
Hi,

I recently tried to setup your wonderful software! However, I was not able to get it to work with my custom GitLab instance. Since I am no Go developer by all means, I've asked Claude for assistance. Claude told me, that the gitlab-backup software did not set the gitlab uri and token correctly from the config and proposed this PR.

I've tried to review it, it looks ok to me. Maybe you can have a second look.

Kind regards,
Fatih