### PR TITLE
test: expand black-box coverage with DI seams

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -85,7 +85,7 @@ var (
 // App represents the main application structure.
 type App struct {
 	cfg           *config.Config
-	gitlabService *gitlab.Service
+	gitlabService gitlab.BackupService
 	storage       storage.Storage
 	log           Logger
 }
@@ -149,6 +149,23 @@ func NewApp(ctx context.Context, cfg *config.Config, log Logger) (*App, error) {
 		}
 	}
 	return app, nil
+}
+
+// NewAppWithService builds an App from already-constructed dependencies. Unlike
+// NewApp it performs no GitLab client or storage construction and no connection
+// wiring: the caller supplies a ready BackupService and Storage. It is intended
+// for testing and advanced wiring. A nil logger discards logs.
+func NewAppWithService(cfg *config.Config, svc gitlab.BackupService, store storage.Storage, log Logger) *App {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	gitlab.SetLogger(log)
+	return &App{
+		cfg:           cfg,
+		gitlabService: svc,
+		storage:       store,
+		log:           log,
+	}
 }
 
 // SetLogger sets the logger.

--- a/pkg/app/app_blackbox_test.go
+++ b/pkg/app/app_blackbox_test.go
@@ -1,0 +1,315 @@
+package app_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sgaunet/gitlab-backup/pkg/app"
+	"github.com/sgaunet/gitlab-backup/pkg/config"
+	"github.com/sgaunet/gitlab-backup/pkg/gitlab"
+	gitlabMocks "github.com/sgaunet/gitlab-backup/pkg/gitlab/mocks"
+	"github.com/sgaunet/gitlab-backup/pkg/hooks"
+	"github.com/sgaunet/gitlab-backup/pkg/storage/localstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A known-good age recipient (public key) reused from the config testdata.
+const testAgeRecipient = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
+
+// stubStorage is a minimal storage.Storage used to exercise the StoreArchive
+// error path without a real backend.
+type stubStorage struct {
+	err   error
+	calls int
+}
+
+func (s *stubStorage) SaveFile(_ context.Context, _, _ string) error {
+	s.calls++
+	return s.err
+}
+
+// baseConfig returns a config with temp TmpDir/LocalPath so archives can be
+// written and stored on the local filesystem.
+func baseConfig(t *testing.T) (*config.Config, string) {
+	t.Helper()
+	storageDir := t.TempDir()
+	cfg := &config.Config{
+		GitlabURI: "https://gitlab.com",
+		TmpDir:    t.TempDir(),
+		LocalPath: storageDir,
+	}
+	return cfg, storageDir
+}
+
+// writeArchiveFn returns an ExportProject implementation that writes a real
+// (non-empty) archive to the requested path so StoreArchive/encryption can read it.
+func writeArchiveFn(t *testing.T) func(context.Context, *gitlab.Project, string) error {
+	t.Helper()
+	return func(_ context.Context, _ *gitlab.Project, archiveFilePath string) error {
+		return os.WriteFile(archiveFilePath, []byte("archive-bytes"), 0o600)
+	}
+}
+
+func TestApp_Run_Dispatch(t *testing.T) {
+	t.Run("group id dispatches to ExportGroup", func(t *testing.T) {
+		cfg, _ := baseConfig(t)
+		cfg.GitlabGroupID = 10
+
+		called := false
+		svc := &gitlabMocks.BackupServiceMock{
+			GetProjectsOfGroupFunc: func(_ context.Context, groupID int64) ([]gitlab.Project, error) {
+				called = true
+				assert.Equal(t, int64(10), groupID)
+				return nil, nil
+			},
+		}
+		a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+		require.NoError(t, a.Run(context.Background()))
+		assert.True(t, called, "ExportGroup should be invoked")
+	})
+
+	t.Run("project id dispatches to ExportProject", func(t *testing.T) {
+		cfg, _ := baseConfig(t)
+		cfg.GitlabProjectID = 55
+
+		svc := &gitlabMocks.BackupServiceMock{
+			GetProjectFunc: func(_ context.Context, projectID int64) (gitlab.Project, error) {
+				assert.Equal(t, int64(55), projectID)
+				return gitlab.Project{ID: 55, Name: "proj"}, nil
+			},
+			ExportProjectFunc: writeArchiveFn(t),
+		}
+		a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+		require.NoError(t, a.Run(context.Background()))
+		require.Len(t, svc.GetProjectCalls(), 1)
+	})
+
+	t.Run("neither id is a no-op", func(t *testing.T) {
+		cfg, _ := baseConfig(t)
+		svc := &gitlabMocks.BackupServiceMock{}
+		a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+		require.NoError(t, a.Run(context.Background()))
+	})
+}
+
+func TestApp_ExportProject_HappyPath(t *testing.T) {
+	cfg, storageDir := baseConfig(t)
+
+	svc := &gitlabMocks.BackupServiceMock{
+		GetProjectFunc: func(_ context.Context, _ int64) (gitlab.Project, error) {
+			return gitlab.Project{ID: 7, Name: "myproj"}, nil
+		},
+		ExportProjectFunc: writeArchiveFn(t),
+	}
+	a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+
+	require.NoError(t, a.ExportProject(context.Background(), 7))
+
+	// Archive should have landed in storage under its base name...
+	stored := filepath.Join(storageDir, "myproj-7.tar.gz")
+	_, err := os.Stat(stored)
+	require.NoError(t, err, "archive should be stored")
+
+	// ...and the temporary archive removed from TmpDir.
+	tmpArchive := filepath.Join(cfg.TmpDir, "myproj-7.tar.gz")
+	_, statErr := os.Stat(tmpArchive)
+	assert.True(t, os.IsNotExist(statErr), "temp archive should be removed after storing")
+}
+
+func TestApp_ExportProject_GetProjectError(t *testing.T) {
+	cfg, _ := baseConfig(t)
+	svc := &gitlabMocks.BackupServiceMock{
+		GetProjectFunc: func(_ context.Context, _ int64) (gitlab.Project, error) {
+			return gitlab.Project{}, errors.New("boom")
+		},
+	}
+	a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+
+	err := a.ExportProject(context.Background(), 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get project")
+}
+
+func TestApp_ExportProject_ExportError(t *testing.T) {
+	cfg, _ := baseConfig(t)
+	svc := &gitlabMocks.BackupServiceMock{
+		GetProjectFunc: func(_ context.Context, _ int64) (gitlab.Project, error) {
+			return gitlab.Project{ID: 7, Name: "myproj"}, nil
+		},
+		ExportProjectFunc: func(_ context.Context, _ *gitlab.Project, _ string) error {
+			return errors.New("export failed")
+		},
+	}
+	a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+
+	err := a.ExportProject(context.Background(), 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to export project")
+}
+
+func TestApp_StoreArchive_Error(t *testing.T) {
+	cfg, _ := baseConfig(t)
+	stub := &stubStorage{err: errors.New("disk full")}
+	svc := &gitlabMocks.BackupServiceMock{
+		GetProjectFunc: func(_ context.Context, _ int64) (gitlab.Project, error) {
+			return gitlab.Project{ID: 7, Name: "myproj"}, nil
+		},
+		ExportProjectFunc: writeArchiveFn(t),
+	}
+	a := app.NewAppWithService(cfg, svc, stub, nil)
+
+	err := a.ExportProject(context.Background(), 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save file to storage")
+	assert.Equal(t, 1, stub.calls)
+
+	// StoreArchive still removes the temp file even when saving fails.
+	tmpArchive := filepath.Join(cfg.TmpDir, "myproj-7.tar.gz")
+	_, statErr := os.Stat(tmpArchive)
+	assert.True(t, os.IsNotExist(statErr), "temp archive should be removed even on save error")
+}
+
+func TestApp_ExportProject_Hooks(t *testing.T) {
+	t.Run("pre and post hooks succeed", func(t *testing.T) {
+		cfg, _ := baseConfig(t)
+		cfg.Hooks = hooks.Hooks{PreBackup: "true", PostBackup: "true"}
+		svc := &gitlabMocks.BackupServiceMock{
+			GetProjectFunc: func(_ context.Context, _ int64) (gitlab.Project, error) {
+				return gitlab.Project{ID: 7, Name: "myproj"}, nil
+			},
+			ExportProjectFunc: writeArchiveFn(t),
+		}
+		a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+		require.NoError(t, a.ExportProject(context.Background(), 7))
+	})
+
+	t.Run("failing pre-backup hook aborts", func(t *testing.T) {
+		cfg, _ := baseConfig(t)
+		cfg.Hooks = hooks.Hooks{PreBackup: "false"}
+		svc := &gitlabMocks.BackupServiceMock{
+			GetProjectFunc: func(_ context.Context, _ int64) (gitlab.Project, error) {
+				return gitlab.Project{ID: 7, Name: "myproj"}, nil
+			},
+			ExportProjectFunc: writeArchiveFn(t),
+		}
+		a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+		err := a.ExportProject(context.Background(), 7)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pre-backup hook failed")
+	})
+}
+
+func TestApp_ExportProject_Encryption(t *testing.T) {
+	t.Run("inline recipient encrypts before storing", func(t *testing.T) {
+		cfg, storageDir := baseConfig(t)
+		cfg.Age = config.AgeConfig{Recipients: []string{testAgeRecipient}}
+		svc := &gitlabMocks.BackupServiceMock{
+			GetProjectFunc: func(_ context.Context, _ int64) (gitlab.Project, error) {
+				return gitlab.Project{ID: 7, Name: "myproj"}, nil
+			},
+			ExportProjectFunc: writeArchiveFn(t),
+		}
+		a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+		require.NoError(t, a.ExportProject(context.Background(), 7))
+
+		stored := filepath.Join(storageDir, "myproj-7.tar.gz")
+		data, err := os.ReadFile(stored)
+		require.NoError(t, err)
+		assert.NotEqual(t, []byte("archive-bytes"), data, "stored archive should be encrypted, not plaintext")
+	})
+
+	t.Run("recipients file encrypts", func(t *testing.T) {
+		cfg, _ := baseConfig(t)
+		recipientsFile := filepath.Join(t.TempDir(), "recipients.txt")
+		require.NoError(t, os.WriteFile(recipientsFile, []byte(testAgeRecipient+"\n"), 0o600))
+		cfg.Age = config.AgeConfig{RecipientsFile: recipientsFile}
+		svc := &gitlabMocks.BackupServiceMock{
+			GetProjectFunc: func(_ context.Context, _ int64) (gitlab.Project, error) {
+				return gitlab.Project{ID: 7, Name: "myproj"}, nil
+			},
+			ExportProjectFunc: writeArchiveFn(t),
+		}
+		a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+		require.NoError(t, a.ExportProject(context.Background(), 7))
+	})
+
+	t.Run("invalid recipient errors", func(t *testing.T) {
+		cfg, _ := baseConfig(t)
+		cfg.Age = config.AgeConfig{Recipients: []string{"not-a-valid-age-key"}}
+		svc := &gitlabMocks.BackupServiceMock{
+			GetProjectFunc: func(_ context.Context, _ int64) (gitlab.Project, error) {
+				return gitlab.Project{ID: 7, Name: "myproj"}, nil
+			},
+			ExportProjectFunc: writeArchiveFn(t),
+		}
+		a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+		err := a.ExportProject(context.Background(), 7)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "age encryption")
+	})
+}
+
+func TestApp_ExportGroup_ArchivedSkipAndFailureSummary(t *testing.T) {
+	cfg, _ := baseConfig(t)
+	cfg.GitlabGroupID = 100
+
+	svc := &gitlabMocks.BackupServiceMock{
+		GetProjectsOfGroupFunc: func(_ context.Context, _ int64) ([]gitlab.Project, error) {
+			return []gitlab.Project{
+				{ID: 1, Name: "ok"},
+				{ID: 2, Name: "arch", Archived: true},
+				{ID: 3, Name: "boom"},
+			}, nil
+		},
+		GetProjectFunc: func(_ context.Context, projectID int64) (gitlab.Project, error) {
+			switch projectID {
+			case 1:
+				return gitlab.Project{ID: 1, Name: "ok"}, nil
+			case 3:
+				return gitlab.Project{ID: 3, Name: "boom"}, nil
+			default:
+				return gitlab.Project{}, errors.New("unexpected project id")
+			}
+		},
+		ExportProjectFunc: func(_ context.Context, project *gitlab.Project, archiveFilePath string) error {
+			if project.ID == 3 {
+				return errors.New("export exploded")
+			}
+			return os.WriteFile(archiveFilePath, []byte("archive-bytes"), 0o600)
+		},
+	}
+	a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+
+	err := a.ExportGroup(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, app.ErrBackupErrors)
+
+	// Archived project 2 must be skipped (never fetched/exported).
+	for _, c := range svc.GetProjectCalls() {
+		assert.NotEqual(t, int64(2), c.ProjectID, "archived project should never be fetched")
+	}
+	// Only projects 1 and 3 are processed.
+	assert.Len(t, svc.GetProjectCalls(), 2)
+}
+
+func TestApp_ExportGroup_AllSuccess(t *testing.T) {
+	cfg, _ := baseConfig(t)
+	cfg.GitlabGroupID = 100
+
+	svc := &gitlabMocks.BackupServiceMock{
+		GetProjectsOfGroupFunc: func(_ context.Context, _ int64) ([]gitlab.Project, error) {
+			return []gitlab.Project{{ID: 1, Name: "a"}, {ID: 2, Name: "b"}}, nil
+		},
+		GetProjectFunc: func(_ context.Context, projectID int64) (gitlab.Project, error) {
+			return gitlab.Project{ID: projectID, Name: "p"}, nil
+		},
+		ExportProjectFunc: writeArchiveFn(t),
+	}
+	a := app.NewAppWithService(cfg, svc, localstorage.NewLocalStorage(cfg.LocalPath), nil)
+
+	require.NoError(t, a.ExportGroup(context.Background()))
+}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sgaunet/gitlab-backup/pkg/config"
 	"github.com/sgaunet/gitlab-backup/pkg/constants"
+	"github.com/sgaunet/gitlab-backup/pkg/gitlab"
 )
 
 // TestNewApp_AppliesGitlabConfig is a regression test for the bug where the
@@ -31,7 +32,13 @@ func TestNewApp_AppliesGitlabConfig(t *testing.T) {
 	if app.gitlabService == nil {
 		t.Fatal("expected gitlabService to be initialized")
 	}
-	if got := app.gitlabService.GitlabEndpoint(); got != cfg.GitlabURI {
+	// NewApp builds a concrete *gitlab.Service; GitlabEndpoint is not part of the
+	// injectable BackupService interface, so reach it via a type assertion.
+	svc, ok := app.gitlabService.(*gitlab.Service)
+	if !ok {
+		t.Fatalf("expected gitlabService to be *gitlab.Service, got %T", app.gitlabService)
+	}
+	if got := svc.GitlabEndpoint(); got != cfg.GitlabURI {
 		t.Errorf("expected endpoint %q to be applied from config, got %q", cfg.GitlabURI, got)
 	}
 }
@@ -71,8 +78,14 @@ func TestNewApp_HonorsConfiguredToken(t *testing.T) {
 
 	// Drive a real request through the app's GitLab service and inspect the wire.
 	// The returned error is irrelevant here: we only care that the request was
-	// sent to the configured endpoint carrying the configured token.
-	_, _ = app.gitlabService.GetGroup(context.Background(), 42)
+	// sent to the configured endpoint carrying the configured token. GetGroup is
+	// not on the injectable BackupService interface, so reach it via the concrete
+	// service NewApp built.
+	svc, ok := app.gitlabService.(*gitlab.Service)
+	if !ok {
+		t.Fatalf("expected gitlabService to be *gitlab.Service, got %T", app.gitlabService)
+	}
+	_, _ = svc.GetGroup(context.Background(), 42)
 
 	if !hit {
 		t.Fatal("expected the request to reach the configured gitlabURI, but the stub server was never called")

--- a/pkg/app/restore/orchestrator_success_test.go
+++ b/pkg/app/restore/orchestrator_success_test.go
@@ -1,0 +1,134 @@
+package restore_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sgaunet/gitlab-backup/pkg/app/restore"
+	restoreMocks "github.com/sgaunet/gitlab-backup/pkg/app/restore/mocks"
+	"github.com/sgaunet/gitlab-backup/pkg/config"
+	"github.com/sgaunet/gitlab-backup/pkg/gitlab"
+	gitlabMocks "github.com/sgaunet/gitlab-backup/pkg/gitlab/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitlabAPI "gitlab.com/gitlab-org/api/client-go"
+)
+
+// createValidArchive writes a genuinely valid .tar.gz so ExtractArchive's
+// gzip/tar validation passes and the workflow reaches the import phase.
+func createValidArchive(t *testing.T) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	body := []byte("project export placeholder")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "project.bundle",
+		Mode: 0o600,
+		Size: int64(len(body)),
+	}))
+	_, err := tw.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+
+	archivePath := filepath.Join(t.TempDir(), "valid-archive.tar.gz")
+	require.NoError(t, os.WriteFile(archivePath, buf.Bytes(), 0o600))
+	return archivePath
+}
+
+// withImportSuccess customizes the mock GitLab client so ImportFromFile is
+// accepted and the first ImportStatus poll reports "finished".
+func withImportSuccess(client *gitlabMocks.GitLabClientMock) {
+	client.ProjectImportExportFunc = func() gitlab.ProjectImportExportService {
+		return &gitlabMocks.ProjectImportExportServiceMock{
+			ImportFromFileFunc: func(_ context.Context, _ io.Reader, _ *gitlabAPI.ImportFileOptions, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.ImportStatus, *gitlabAPI.Response, error) {
+				return &gitlabAPI.ImportStatus{ID: 42, ImportStatus: "scheduled"}, &gitlabAPI.Response{}, nil
+			},
+			ImportStatusFunc: func(_ context.Context, _ any, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.ImportStatus, *gitlabAPI.Response, error) {
+				return &gitlabAPI.ImportStatus{ID: 42, ImportStatus: "finished"}, &gitlabAPI.Response{}, nil
+			},
+		}
+	}
+}
+
+func successRestoreConfig(t *testing.T, archivePath string) *config.Config {
+	t.Helper()
+	return &config.Config{
+		GitlabURI:         "https://gitlab.com",
+		RestoreSource:     archivePath,
+		RestoreTargetNS:   "test-ns",
+		RestoreTargetPath: "test-project",
+		RestoreOverwrite:  true, // skip validation phase
+		StorageType:       "local",
+		TmpDir:            t.TempDir(),
+		ImportTimeoutMins: 60,
+	}
+}
+
+// TestRestore_FullSuccess_NoOpProgress drives the whole workflow to completion
+// with the NoOp reporter, covering the success paths of Restore (extraction →
+// import → complete) and the NoOpProgressReporter methods.
+func TestRestore_FullSuccess_NoOpProgress(t *testing.T) {
+	mockGitLab := setupMockGitLabService(t, withImportSuccess)
+	mockStorage := setupMockStorage(t)
+	cfg := successRestoreConfig(t, createValidArchive(t))
+
+	orchestrator := restore.NewOrchestratorWithProgress(mockGitLab, mockStorage, restore.NewNoOpProgressReporter())
+	result, err := orchestrator.Restore(context.Background(), cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Success)
+	assert.Equal(t, int64(42), result.ProjectID)
+	assert.Empty(t, result.Errors)
+}
+
+// TestRestore_FullSuccess_MockProgress asserts the phase transitions reported
+// during a successful restore, using the injectable ProgressReporter seam.
+func TestRestore_FullSuccess_MockProgress(t *testing.T) {
+	mockGitLab := setupMockGitLabService(t, withImportSuccess)
+	mockStorage := setupMockStorage(t)
+	cfg := successRestoreConfig(t, createValidArchive(t))
+
+	progress := &restoreMocks.ProgressReporterMock{
+		StartPhaseFunc:    func(_ restore.Phase) {},
+		UpdatePhaseFunc:   func(_ restore.Phase, _, _ int) {},
+		CompletePhaseFunc: func(_ restore.Phase) {},
+		FailPhaseFunc:     func(_ restore.Phase, _ error) {},
+		SkipPhaseFunc:     func(_ restore.Phase, _ string) {},
+	}
+
+	orchestrator := restore.NewOrchestratorWithProgress(mockGitLab, mockStorage, progress)
+	result, err := orchestrator.Restore(context.Background(), cfg)
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+
+	// Validation is skipped (overwrite), extraction + import must complete.
+	started := make(map[restore.Phase]bool)
+	for _, c := range progress.StartPhaseCalls() {
+		started[c.Phase] = true
+	}
+	assert.True(t, started[restore.PhaseExtraction], "extraction phase should start")
+	assert.True(t, started[restore.PhaseImport], "import phase should start")
+
+	completed := make(map[restore.Phase]bool)
+	for _, c := range progress.CompletePhaseCalls() {
+		completed[c.Phase] = true
+	}
+	assert.True(t, completed[restore.PhaseImport], "import phase should complete")
+
+	// Overwrite means validation is skipped, never failed.
+	for _, c := range progress.FailPhaseCalls() {
+		assert.NotEqual(t, restore.PhaseValidation, c.Phase)
+	}
+	assert.NotEmpty(t, progress.SkipPhaseCalls(), "validation should be skipped with overwrite")
+}

--- a/pkg/app/restore/orchestrator_test.go
+++ b/pkg/app/restore/orchestrator_test.go
@@ -1,25 +1,26 @@
-package restore
+package restore_test
 
 import (
 	"testing"
 	"time"
 
+	"github.com/sgaunet/gitlab-backup/pkg/app/restore"
 	"github.com/stretchr/testify/assert"
 )
 
 // TestPhaseConstants tests that phase constants are correctly defined.
 func TestPhaseConstants(t *testing.T) {
-	phases := []Phase{
-		PhaseValidation,
-		PhaseDownload,
-		PhaseExtraction,
-		PhaseImport,
-		PhaseCleanup,
-		PhaseComplete,
+	phases := []restore.Phase{
+		restore.PhaseValidation,
+		restore.PhaseDownload,
+		restore.PhaseExtraction,
+		restore.PhaseImport,
+		restore.PhaseCleanup,
+		restore.PhaseComplete,
 	}
 
 	// Verify all phases are unique
-	phaseMap := make(map[Phase]bool)
+	phaseMap := make(map[restore.Phase]bool)
 	for _, phase := range phases {
 		assert.False(t, phaseMap[phase], "Phase %s should be unique", phase)
 		phaseMap[phase] = true
@@ -32,15 +33,15 @@ func TestPhaseConstants(t *testing.T) {
 // TestErrorStructure tests the Error type.
 func TestErrorStructure(t *testing.T) {
 	now := time.Now()
-	err := Error{
-		Phase:     PhaseImport,
+	err := restore.Error{
+		Phase:     restore.PhaseImport,
 		Component: "GitLabImport",
 		Message:   "import failed",
 		Fatal:     true,
 		Timestamp: now,
 	}
 
-	assert.Equal(t, PhaseImport, err.Phase)
+	assert.Equal(t, restore.PhaseImport, err.Phase)
 	assert.Equal(t, "GitLabImport", err.Component)
 	assert.Equal(t, "import failed", err.Message)
 	assert.True(t, err.Fatal)
@@ -49,7 +50,7 @@ func TestErrorStructure(t *testing.T) {
 
 // TestMetricsStructure tests the Metrics type.
 func TestMetricsStructure(t *testing.T) {
-	metrics := Metrics{
+	metrics := restore.Metrics{
 		BytesDownloaded: 1024,
 		BytesExtracted:  2048,
 		DurationSeconds: 60,
@@ -63,7 +64,7 @@ func TestMetricsStructure(t *testing.T) {
 // TestEmptinessChecks_IsEmpty tests the IsEmpty method.
 func TestEmptinessChecks_IsEmpty(t *testing.T) {
 	t.Run("EmptyProject", func(t *testing.T) {
-		checks := &EmptinessChecks{
+		checks := &restore.EmptinessChecks{
 			HasCommits: false,
 			HasIssues:  false,
 			HasLabels:  false,
@@ -72,7 +73,7 @@ func TestEmptinessChecks_IsEmpty(t *testing.T) {
 	})
 
 	t.Run("ProjectWithCommits", func(t *testing.T) {
-		checks := &EmptinessChecks{
+		checks := &restore.EmptinessChecks{
 			HasCommits:  true,
 			HasIssues:   false,
 			HasLabels:   false,
@@ -82,7 +83,7 @@ func TestEmptinessChecks_IsEmpty(t *testing.T) {
 	})
 
 	t.Run("ProjectWithMultipleItems", func(t *testing.T) {
-		checks := &EmptinessChecks{
+		checks := &restore.EmptinessChecks{
 			HasCommits:  true,
 			HasIssues:   true,
 			HasLabels:   true,

--- a/pkg/app/restore/progress_test.go
+++ b/pkg/app/restore/progress_test.go
@@ -1,11 +1,13 @@
-package restore
+package restore_test
 
 import (
+	"bytes"
 	"errors"
 	"log/slog"
 	"os"
 	"testing"
 
+	"github.com/sgaunet/gitlab-backup/pkg/app/restore"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,77 +22,77 @@ func TestConsoleProgressReporter_AllPhases(t *testing.T) {
 		},
 	}))
 
-	reporter := NewConsoleProgressReporter(logger)
+	reporter := restore.NewConsoleProgressReporter(logger)
 
 	// Test all phase operations - verify no panics
 	t.Run("StartPhase", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			reporter.StartPhase(PhaseValidation)
-			reporter.StartPhase(PhaseDownload)
-			reporter.StartPhase(PhaseExtraction)
-			reporter.StartPhase(PhaseImport)
-			reporter.StartPhase(PhaseCleanup)
+			reporter.StartPhase(restore.PhaseValidation)
+			reporter.StartPhase(restore.PhaseDownload)
+			reporter.StartPhase(restore.PhaseExtraction)
+			reporter.StartPhase(restore.PhaseImport)
+			reporter.StartPhase(restore.PhaseCleanup)
 		})
 	})
 
 	t.Run("UpdatePhase", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			reporter.UpdatePhase(PhaseImport, 5, 10)
-			reporter.UpdatePhase(PhaseExtraction, 100, 200)
+			reporter.UpdatePhase(restore.PhaseImport, 5, 10)
+			reporter.UpdatePhase(restore.PhaseExtraction, 100, 200)
 		})
 	})
 
 	t.Run("CompletePhase", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			reporter.CompletePhase(PhaseValidation)
-			reporter.CompletePhase(PhaseDownload)
-			reporter.CompletePhase(PhaseExtraction)
-			reporter.CompletePhase(PhaseImport)
+			reporter.CompletePhase(restore.PhaseValidation)
+			reporter.CompletePhase(restore.PhaseDownload)
+			reporter.CompletePhase(restore.PhaseExtraction)
+			reporter.CompletePhase(restore.PhaseImport)
 		})
 	})
 
 	t.Run("FailPhase", func(t *testing.T) {
 		testErr := errors.New("test error")
 		assert.NotPanics(t, func() {
-			reporter.FailPhase(PhaseValidation, testErr)
-			reporter.FailPhase(PhaseImport, testErr)
+			reporter.FailPhase(restore.PhaseValidation, testErr)
+			reporter.FailPhase(restore.PhaseImport, testErr)
 		})
 	})
 
 	t.Run("SkipPhase", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			reporter.SkipPhase(PhaseValidation, "overwrite flag set")
-			reporter.SkipPhase(PhaseDownload, "local restore")
+			reporter.SkipPhase(restore.PhaseValidation, "overwrite flag set")
+			reporter.SkipPhase(restore.PhaseDownload, "local restore")
 		})
 	})
 
 	t.Run("CompleteWorkflow", func(t *testing.T) {
 		// Simulate complete workflow
 		assert.NotPanics(t, func() {
-			reporter.StartPhase(PhaseValidation)
-			reporter.CompletePhase(PhaseValidation)
+			reporter.StartPhase(restore.PhaseValidation)
+			reporter.CompletePhase(restore.PhaseValidation)
 
-			reporter.StartPhase(PhaseExtraction)
-			reporter.UpdatePhase(PhaseExtraction, 50, 100)
-			reporter.CompletePhase(PhaseExtraction)
+			reporter.StartPhase(restore.PhaseExtraction)
+			reporter.UpdatePhase(restore.PhaseExtraction, 50, 100)
+			reporter.CompletePhase(restore.PhaseExtraction)
 
-			reporter.StartPhase(PhaseImport)
-			reporter.CompletePhase(PhaseImport)
+			reporter.StartPhase(restore.PhaseImport)
+			reporter.CompletePhase(restore.PhaseImport)
 		})
 	})
 }
 
 func TestNoOpProgressReporter_NoOutput(t *testing.T) {
-	reporter := NewNoOpProgressReporter()
+	reporter := restore.NewNoOpProgressReporter()
 
 	// All operations should complete without panics or side effects
 	t.Run("AllOperationsNoOp", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			reporter.StartPhase(PhaseValidation)
-			reporter.UpdatePhase(PhaseImport, 1, 10)
-			reporter.CompletePhase(PhaseValidation)
-			reporter.FailPhase(PhaseImport, errors.New("test error"))
-			reporter.SkipPhase(PhaseDownload, "reason")
+			reporter.StartPhase(restore.PhaseValidation)
+			reporter.UpdatePhase(restore.PhaseImport, 1, 10)
+			reporter.CompletePhase(restore.PhaseValidation)
+			reporter.FailPhase(restore.PhaseImport, errors.New("test error"))
+			reporter.SkipPhase(restore.PhaseDownload, "reason")
 		})
 	})
 
@@ -98,62 +100,75 @@ func TestNoOpProgressReporter_NoOutput(t *testing.T) {
 		assert.NotPanics(t, func() {
 			// Call each method multiple times
 			for i := 0; i < 100; i++ {
-				reporter.StartPhase(PhaseValidation)
-				reporter.UpdatePhase(PhaseImport, i, 100)
-				reporter.CompletePhase(PhaseValidation)
-				reporter.FailPhase(PhaseImport, errors.New("error"))
-				reporter.SkipPhase(PhaseDownload, "skip")
+				reporter.StartPhase(restore.PhaseValidation)
+				reporter.UpdatePhase(restore.PhaseImport, i, 100)
+				reporter.CompletePhase(restore.PhaseValidation)
+				reporter.FailPhase(restore.PhaseImport, errors.New("error"))
+				reporter.SkipPhase(restore.PhaseDownload, "skip")
 			}
 		})
 	})
 }
 
-func TestGetPhaseStartMessage_AllPhases(t *testing.T) {
+// TestConsoleProgressReporter_PhaseMessages verifies the human-readable message
+// emitted for each phase. It is the black-box replacement for the previous
+// white-box test of the unexported getPhaseStartMessage: the message is asserted
+// through StartPhase's logged output captured from a buffer.
+func TestConsoleProgressReporter_PhaseMessages(t *testing.T) {
 	tests := []struct {
-		phase           Phase
+		phase           restore.Phase
 		expectedMessage string
 	}{
-		{PhaseValidation, "Validating project emptiness"},
-		{PhaseDownload, "Downloading archive from S3"},
-		{PhaseExtraction, "Extracting archive"},
-		{PhaseImport, "Importing repository"},
-		{PhaseCleanup, "Cleaning up temporary files"},
-		{PhaseComplete, "Restore complete"},
+		{restore.PhaseValidation, "Validating project emptiness"},
+		{restore.PhaseDownload, "Downloading archive from S3"},
+		{restore.PhaseExtraction, "Extracting archive"},
+		{restore.PhaseImport, "Importing repository"},
+		{restore.PhaseCleanup, "Cleaning up temporary files"},
+		{restore.PhaseComplete, "Restore complete"},
 	}
 
 	for _, tt := range tests {
 		t.Run(string(tt.phase), func(t *testing.T) {
-			message := getPhaseStartMessage(tt.phase)
-			assert.Equal(t, tt.expectedMessage, message, "Phase message should match expected")
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, nil))
+			reporter := restore.NewConsoleProgressReporter(logger)
+
+			reporter.StartPhase(tt.phase)
+
+			assert.Contains(t, buf.String(), tt.expectedMessage, "Phase message should match expected")
 		})
 	}
 
 	t.Run("UnknownPhase", func(t *testing.T) {
-		unknownPhase := Phase("unknown")
-		message := getPhaseStartMessage(unknownPhase)
-		assert.Equal(t, "unknown", message, "Unknown phase should return phase string")
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		reporter := restore.NewConsoleProgressReporter(logger)
+
+		reporter.StartPhase(restore.Phase("unknown"))
+
+		assert.Contains(t, buf.String(), "unknown", "Unknown phase should log the phase string")
 	})
 }
 
 func TestConsoleProgressReporter_Creation(t *testing.T) {
 	t.Run("WithLogger", func(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-		reporter := NewConsoleProgressReporter(logger)
+		reporter := restore.NewConsoleProgressReporter(logger)
 
 		assert.NotNil(t, reporter, "Reporter should not be nil")
 		assert.NotPanics(t, func() {
-			reporter.StartPhase(PhaseValidation)
+			reporter.StartPhase(restore.PhaseValidation)
 		})
 	})
 }
 
 func TestNoOpProgressReporter_Creation(t *testing.T) {
 	t.Run("Creation", func(t *testing.T) {
-		reporter := NewNoOpProgressReporter()
+		reporter := restore.NewNoOpProgressReporter()
 
 		assert.NotNil(t, reporter, "Reporter should not be nil")
 		assert.NotPanics(t, func() {
-			reporter.StartPhase(PhaseValidation)
+			reporter.StartPhase(restore.PhaseValidation)
 		})
 	})
 }

--- a/pkg/app/restore/restore.go
+++ b/pkg/app/restore/restore.go
@@ -46,10 +46,22 @@ func NewOrchestrator(gitlabClient gitlab.GitLabService, storage Storage, cfg *co
 		logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 	}
 
+	return NewOrchestratorWithProgress(gitlabClient, storage, NewConsoleProgressReporter(logger))
+}
+
+// NewOrchestratorWithProgress creates a restore orchestrator with an explicit
+// progress reporter. It is intended for testing and custom progress UIs: pass
+// NewNoOpProgressReporter() to silence console output, or a mock to assert phase
+// transitions. Unlike NewOrchestrator it builds no logger and reads no config.
+func NewOrchestratorWithProgress(
+	gitlabClient gitlab.GitLabService,
+	storage Storage,
+	progress ProgressReporter,
+) *Orchestrator {
 	return &Orchestrator{
 		gitlabClient: gitlabClient,
 		storage:      storage,
-		progress:     NewConsoleProgressReporter(logger),
+		progress:     progress,
 	}
 }
 

--- a/pkg/config/restore_config_test.go
+++ b/pkg/config/restore_config_test.go
@@ -1,0 +1,255 @@
+package config_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sgaunet/gitlab-backup/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+// baseValidRestoreConfig returns a RestoreConfig whose embedded Config passes
+// the base backup Validate() (which ValidateRestore calls first). TmpDir points
+// at a real writable directory so validateTmpDir succeeds. Restore-specific
+// fields are left to the caller.
+func baseValidRestoreConfig(t *testing.T) *config.RestoreConfig {
+	t.Helper()
+	dir := t.TempDir()
+	return &config.RestoreConfig{
+		Config: config.Config{
+			GitlabGroupID:     123,
+			GitlabToken:       "test-token",
+			GitlabURI:         "https://gitlab.com",
+			LocalPath:         dir,
+			TmpDir:            dir,
+			ExportTimeoutMins: 10,
+			ImportTimeoutMins: 60,
+		},
+	}
+}
+
+func TestRestoreConfig_IsS3Source(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   bool
+	}{
+		{"s3 source", "s3://bucket/key", true},
+		{"local tar.gz", "/data/archive.tar.gz", false},
+		{"empty", "", false},
+		{"s3 prefix only", "s3://", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &config.RestoreConfig{RestoreSource: tc.source}
+			require.Equal(t, tc.want, c.IsS3Source())
+		})
+	}
+}
+
+func TestRestoreConfig_ParseS3Source(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		c := &config.RestoreConfig{RestoreSource: "s3://my-bucket/path/to/archive.tar.gz"}
+		bucket, key, err := c.ParseS3Source()
+		require.NoError(t, err)
+		require.Equal(t, "my-bucket", bucket)
+		require.Equal(t, "path/to/archive.tar.gz", key)
+	})
+
+	t.Run("not an s3 source", func(t *testing.T) {
+		c := &config.RestoreConfig{RestoreSource: "/local/archive.tar.gz"}
+		_, _, err := c.ParseS3Source()
+		require.ErrorIs(t, err, config.ErrNotS3Source)
+	})
+
+	t.Run("missing key separator", func(t *testing.T) {
+		c := &config.RestoreConfig{RestoreSource: "s3://bucketonly"}
+		_, _, err := c.ParseS3Source()
+		require.ErrorIs(t, err, config.ErrInvalidS3PathFormat)
+	})
+
+	t.Run("empty bucket", func(t *testing.T) {
+		c := &config.RestoreConfig{RestoreSource: "s3:///key"}
+		_, _, err := c.ParseS3Source()
+		require.ErrorIs(t, err, config.ErrInvalidS3Path)
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		c := &config.RestoreConfig{RestoreSource: "s3://bucket/"}
+		_, _, err := c.ParseS3Source()
+		require.ErrorIs(t, err, config.ErrInvalidS3Path)
+	})
+}
+
+func TestRestoreConfig_GetFullProjectPath(t *testing.T) {
+	t.Run("no namespace", func(t *testing.T) {
+		c := &config.RestoreConfig{RestoreTargetPath: "myproject"}
+		require.Equal(t, "myproject", c.GetFullProjectPath())
+	})
+
+	t.Run("with namespace", func(t *testing.T) {
+		c := &config.RestoreConfig{RestoreTargetNS: "group/sub", RestoreTargetPath: "myproject"}
+		require.Equal(t, filepath.Join("group/sub", "myproject"), c.GetFullProjectPath())
+	})
+}
+
+func TestRestoreConfig_ValidateRestore_Source(t *testing.T) {
+	t.Run("empty source", func(t *testing.T) {
+		c := baseValidRestoreConfig(t)
+		c.RestoreTargetPath = "proj"
+		c.RestoreSource = ""
+		err := c.ValidateRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "restoreSource is required")
+	})
+
+	t.Run("s3 source without valid s3 config", func(t *testing.T) {
+		c := baseValidRestoreConfig(t)
+		c.RestoreTargetPath = "proj"
+		c.RestoreSource = "s3://bucket/archive.tar.gz"
+		// No S3cfg set -> IsS3ConfigValid() is false.
+		err := c.ValidateRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "S3 configuration required")
+	})
+
+	t.Run("local source not tar.gz", func(t *testing.T) {
+		c := baseValidRestoreConfig(t)
+		c.RestoreTargetPath = "proj"
+		c.RestoreSource = "/data/archive.zip"
+		err := c.ValidateRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), ".tar.gz file")
+	})
+
+	t.Run("local source with path traversal", func(t *testing.T) {
+		c := baseValidRestoreConfig(t)
+		c.RestoreTargetPath = "proj"
+		c.RestoreSource = "../../etc/archive.tar.gz"
+		err := c.ValidateRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "traversal")
+	})
+
+	t.Run("valid local source", func(t *testing.T) {
+		c := baseValidRestoreConfig(t)
+		c.RestoreTargetPath = "proj"
+		c.RestoreSource = filepath.Join(c.LocalPath, "archive.tar.gz")
+		require.NoError(t, c.ValidateRestore())
+	})
+
+	t.Run("valid s3 source", func(t *testing.T) {
+		c := baseValidRestoreConfig(t)
+		c.RestoreTargetPath = "proj"
+		c.RestoreSource = "s3://my-backup-bucket/archive.tar.gz"
+		c.S3cfg = config.S3Config{
+			BucketName: "my-backup-bucket",
+			BucketPath: "backups",
+			Region:     "us-east-1",
+		}
+		require.NoError(t, c.ValidateRestore())
+	})
+}
+
+func TestRestoreConfig_ValidateRestore_Target(t *testing.T) {
+	validSource := func(c *config.RestoreConfig) {
+		c.RestoreSource = filepath.Join(c.LocalPath, "archive.tar.gz")
+	}
+
+	t.Run("empty target path", func(t *testing.T) {
+		c := baseValidRestoreConfig(t)
+		validSource(c)
+		c.RestoreTargetPath = ""
+		err := c.ValidateRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "restoreTargetPath is required")
+	})
+
+	t.Run("invalid target path characters", func(t *testing.T) {
+		c := baseValidRestoreConfig(t)
+		validSource(c)
+		c.RestoreTargetPath = "invalid path"
+		err := c.ValidateRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid restoreTargetPath")
+	})
+
+	t.Run("valid nested namespace", func(t *testing.T) {
+		c := baseValidRestoreConfig(t)
+		validSource(c)
+		c.RestoreTargetPath = "proj"
+		c.RestoreTargetNS = "group/subgroup"
+		require.NoError(t, c.ValidateRestore())
+	})
+
+	t.Run("namespace with empty segment", func(t *testing.T) {
+		c := baseValidRestoreConfig(t)
+		validSource(c)
+		c.RestoreTargetPath = "proj"
+		c.RestoreTargetNS = "group//sub"
+		err := c.ValidateRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "empty path segments")
+	})
+
+	t.Run("namespace with invalid segment", func(t *testing.T) {
+		c := baseValidRestoreConfig(t)
+		validSource(c)
+		c.RestoreTargetPath = "proj"
+		c.RestoreTargetNS = "group/bad segment"
+		err := c.ValidateRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid restoreTargetNS")
+	})
+}
+
+func TestConfig_ValidateForRestore(t *testing.T) {
+	baseValid := func(t *testing.T) *config.Config {
+		t.Helper()
+		dir := t.TempDir()
+		return &config.Config{
+			GitlabToken:       "test-token",
+			GitlabURI:         "https://gitlab.com",
+			TmpDir:            dir,
+			ExportTimeoutMins: 10,
+			ImportTimeoutMins: 60,
+		}
+	}
+
+	t.Run("happy path does not require group or project id", func(t *testing.T) {
+		c := baseValid(t)
+		require.NoError(t, c.ValidateForRestore())
+	})
+
+	t.Run("missing token", func(t *testing.T) {
+		c := baseValid(t)
+		c.GitlabToken = ""
+		err := c.ValidateForRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "gitlabToken is required")
+	})
+
+	t.Run("invalid gitlab uri scheme", func(t *testing.T) {
+		c := baseValid(t)
+		c.GitlabURI = "ftp://gitlab.example.com"
+		err := c.ValidateForRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "http or https scheme")
+	})
+
+	t.Run("tmpdir does not exist", func(t *testing.T) {
+		c := baseValid(t)
+		c.TmpDir = filepath.Join(t.TempDir(), "does-not-exist")
+		err := c.ValidateForRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tmpdir")
+	})
+
+	t.Run("timeout too low", func(t *testing.T) {
+		c := baseValid(t)
+		c.ExportTimeoutMins = 0
+		err := c.ValidateForRestore()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exportTimeoutMins")
+	})
+}

--- a/pkg/gitlab/client_wrapper_blackbox_test.go
+++ b/pkg/gitlab/client_wrapper_blackbox_test.go
@@ -1,0 +1,274 @@
+package gitlab_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sgaunet/gitlab-backup/pkg/gitlab"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitlabAPI "gitlab.com/gitlab-org/api/client-go"
+)
+
+// newWrappedClient builds a real GitLab client pointed at srv and wraps it with
+// the production NewGitLabClientWrapper, so the retry wrappers are exercised
+// end-to-end over HTTP without touching gitlab.com.
+func newWrappedClient(t *testing.T, srv *httptest.Server) gitlab.GitLabClient {
+	t.Helper()
+	// WithoutRetries disables the client-go built-in retryablehttp backoff so the
+	// wrapper's own retry logic (retry.go) is the only retry under test — keeping
+	// 5xx-based tests fast and deterministic.
+	c, err := gitlabAPI.NewClient("test-token", gitlabAPI.WithBaseURL(srv.URL), gitlabAPI.WithoutRetries())
+	require.NoError(t, err)
+	return gitlab.NewGitLabClientWrapper(c)
+}
+
+func writeJSON(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
+}
+
+// apiRouter returns a handler that serves minimal valid responses for every
+// endpoint the wrappers touch. Order matters: more specific suffixes first.
+func apiRouter() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/api/v4/")
+		switch {
+		case r.Method == http.MethodGet && path == "groups/456":
+			writeJSON(w, http.StatusOK, `{"id":456,"name":"grp"}`)
+		case r.Method == http.MethodGet && path == "groups/456/subgroups":
+			writeJSON(w, http.StatusOK, `[{"id":789,"name":"sub"}]`)
+		case r.Method == http.MethodGet && path == "groups/456/projects":
+			writeJSON(w, http.StatusOK, `[{"id":1,"name":"p1"}]`)
+		case r.Method == http.MethodGet && path == "projects/123/export/download":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("BINARY-EXPORT"))
+		case r.Method == http.MethodPost && path == "projects/123/export":
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodGet && path == "projects/123/export":
+			writeJSON(w, http.StatusOK, `{"export_status":"finished"}`)
+		case r.Method == http.MethodPost && path == "projects/import":
+			writeJSON(w, http.StatusCreated, `{"id":77,"import_status":"scheduled"}`)
+		case r.Method == http.MethodGet && path == "projects/123/import":
+			writeJSON(w, http.StatusOK, `{"id":77,"import_status":"finished"}`)
+		case r.Method == http.MethodGet && path == "projects/123/repository/commits":
+			writeJSON(w, http.StatusOK, `[{"id":"abc123"}]`)
+		case r.Method == http.MethodGet && path == "projects/123/labels":
+			writeJSON(w, http.StatusOK, `[{"id":10,"name":"bug"}]`)
+		case r.Method == http.MethodPost && path == "projects/123/labels":
+			writeJSON(w, http.StatusCreated, `{"id":10,"name":"bug"}`)
+		case r.Method == http.MethodPost && path == "projects/123/issues/5/notes":
+			writeJSON(w, http.StatusCreated, `{"id":99,"body":"note"}`)
+		case r.Method == http.MethodGet && path == "projects/123/issues":
+			writeJSON(w, http.StatusOK, `[{"id":50,"iid":5}]`)
+		case r.Method == http.MethodPost && path == "projects/123/issues":
+			writeJSON(w, http.StatusCreated, `{"id":50,"iid":5}`)
+		case r.Method == http.MethodPut && path == "projects/123/issues/5":
+			writeJSON(w, http.StatusOK, `{"id":50,"iid":5,"title":"updated"}`)
+		case r.Method == http.MethodGet && path == "projects/123":
+			writeJSON(w, http.StatusOK, `{"id":123,"name":"proj"}`)
+		default:
+			writeJSON(w, http.StatusNotFound, `{"message":"404 Not Found"}`)
+		}
+	}
+}
+
+func TestWrapper_Groups(t *testing.T) {
+	srv := httptest.NewServer(apiRouter())
+	defer srv.Close()
+	client := newWrappedClient(t, srv)
+	ctx := context.Background()
+
+	group, _, err := client.Groups().GetGroup(ctx, 456, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(456), group.ID)
+
+	subs, _, err := client.Groups().ListSubGroups(ctx, 456, nil)
+	require.NoError(t, err)
+	require.Len(t, subs, 1)
+	assert.Equal(t, int64(789), subs[0].ID)
+
+	projects, _, err := client.Groups().ListGroupProjects(ctx, 456, nil)
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+	assert.Equal(t, int64(1), projects[0].ID)
+}
+
+func TestWrapper_Projects(t *testing.T) {
+	srv := httptest.NewServer(apiRouter())
+	defer srv.Close()
+	client := newWrappedClient(t, srv)
+
+	project, _, err := client.Projects().GetProject(context.Background(), 123, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(123), project.ID)
+}
+
+func TestWrapper_ProjectImportExport(t *testing.T) {
+	srv := httptest.NewServer(apiRouter())
+	defer srv.Close()
+	client := newWrappedClient(t, srv)
+	ctx := context.Background()
+	ie := client.ProjectImportExport()
+
+	resp, err := ie.ScheduleExport(ctx, 123, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+
+	status, _, err := ie.ExportStatus(ctx, 123)
+	require.NoError(t, err)
+	assert.Equal(t, "finished", status.ExportStatus)
+
+	var buf bytes.Buffer
+	_, err = ie.ExportDownloadStream(ctx, 123, &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "BINARY-EXPORT", buf.String())
+
+	imp, _, err := ie.ImportFromFile(ctx, bytes.NewReader([]byte("archive")), &gitlabAPI.ImportFileOptions{
+		Namespace: gitlabAPI.Ptr("ns"),
+		Path:      gitlabAPI.Ptr("proj"),
+		Name:      gitlabAPI.Ptr("proj"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(77), imp.ID)
+
+	impStatus, _, err := ie.ImportStatus(ctx, 123)
+	require.NoError(t, err)
+	assert.Equal(t, "finished", impStatus.ImportStatus)
+}
+
+func TestWrapper_ImportFromFile_ErrorEnrichesContext(t *testing.T) {
+	// A failing import must surface the path/namespace in the wrapped error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusBadRequest, `{"message":"bad request"}`)
+	}))
+	defer srv.Close()
+	client := newWrappedClient(t, srv)
+
+	_, _, err := client.ProjectImportExport().ImportFromFile(context.Background(), bytes.NewReader([]byte("x")),
+		&gitlabAPI.ImportFileOptions{Namespace: gitlabAPI.Ptr("myns"), Path: gitlabAPI.Ptr("mypath")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mypath")
+	assert.Contains(t, err.Error(), "myns")
+}
+
+func TestWrapper_LabelsIssuesNotesCommits(t *testing.T) {
+	srv := httptest.NewServer(apiRouter())
+	defer srv.Close()
+	client := newWrappedClient(t, srv)
+	ctx := context.Background()
+
+	labels, _, err := client.Labels().ListLabels(ctx, 123, nil)
+	require.NoError(t, err)
+	assert.Len(t, labels, 1)
+
+	label, _, err := client.Labels().CreateLabel(ctx, 123, &gitlabAPI.CreateLabelOptions{
+		Name:  gitlabAPI.Ptr("bug"),
+		Color: gitlabAPI.Ptr("#ff0000"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "bug", label.Name)
+
+	issues, _, err := client.Issues().ListProjectIssues(ctx, 123, nil)
+	require.NoError(t, err)
+	assert.Len(t, issues, 1)
+
+	issue, _, err := client.Issues().CreateIssue(ctx, 123, &gitlabAPI.CreateIssueOptions{Title: gitlabAPI.Ptr("t")})
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), issue.IID)
+
+	updated, _, err := client.Issues().UpdateIssue(ctx, 123, 5, &gitlabAPI.UpdateIssueOptions{
+		Title: gitlabAPI.Ptr("updated"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "updated", updated.Title)
+
+	note, _, err := client.Notes().CreateIssueNote(ctx, 123, 5, &gitlabAPI.CreateIssueNoteOptions{
+		Body: gitlabAPI.Ptr("note"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(99), note.ID)
+
+	commits, _, err := client.Commits().ListCommits(ctx, 123, nil)
+	require.NoError(t, err)
+	require.Len(t, commits, 1)
+	assert.Equal(t, "abc123", commits[0].ID)
+}
+
+func TestWrapper_RetryThenSuccess(t *testing.T) {
+	// First response is a retryable 500; the retry wrapper must recover on the
+	// second attempt and return the successful payload.
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			writeJSON(w, http.StatusInternalServerError, `{"message":"boom"}`)
+			return
+		}
+		writeJSON(w, http.StatusOK, `{"id":123,"name":"proj"}`)
+	}))
+	defer srv.Close()
+	client := newWrappedClient(t, srv)
+
+	project, _, err := client.Projects().GetProject(context.Background(), 123, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(123), project.ID)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "should have retried exactly once")
+}
+
+func TestWrapper_NonRetryableErrorReturnsImmediately(t *testing.T) {
+	// A 404 is not retryable: the wrapper must return after a single call.
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		writeJSON(w, http.StatusNotFound, `{"message":"404 Not Found"}`)
+	}))
+	defer srv.Close()
+	client := newWrappedClient(t, srv)
+
+	_, _, err := client.Projects().GetProject(context.Background(), 123, nil)
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "404 must not be retried")
+}
+
+func TestWrapper_RetryStopsOnContextCancellation(t *testing.T) {
+	// Persistent 500 keeps the wrapper retrying; a short context deadline makes
+	// the retry loop abort via the ctx.Done branch instead of backing off ~1s.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusInternalServerError, `{"message":"still failing"}`)
+	}))
+	defer srv.Close()
+	client := newWrappedClient(t, srv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, _, err := client.Projects().GetProject(ctx, 123, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestWrapper_ScheduleExport_RetryThenSuccess(t *testing.T) {
+	// Exercises retryResponseOnly's retry loop (ScheduleExport returns Response only).
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			writeJSON(w, http.StatusServiceUnavailable, `{"message":"try later"}`)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	client := newWrappedClient(t, srv)
+
+	resp, err := client.ProjectImportExport().ScheduleExport(context.Background(), 123, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}

--- a/pkg/gitlab/error_blackbox_test.go
+++ b/pkg/gitlab/error_blackbox_test.go
@@ -1,0 +1,24 @@
+package gitlab_test
+
+import (
+	"testing"
+
+	"github.com/sgaunet/gitlab-backup/pkg/gitlab"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalErrorMessage(t *testing.T) {
+	t.Run("valid api error message", func(t *testing.T) {
+		err := gitlab.UnmarshalErrorMessage([]byte(`{"message":"boom"}`))
+		require.Error(t, err)
+		require.ErrorIs(t, err, gitlab.ErrGitlabAPI)
+		assert.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		err := gitlab.UnmarshalErrorMessage([]byte(`not-json`))
+		require.Error(t, err)
+		require.ErrorIs(t, err, gitlab.ErrUnmarshalJSON)
+	})
+}

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -196,6 +196,7 @@ type Service struct {
 	rateLimitExportAPI    *rate.Limiter
 	rateLimitImportAPI    *rate.Limiter
 	exportTimeoutDuration time.Duration
+	exportCheckInterval   time.Duration
 }
 
 func init() {
@@ -237,6 +238,72 @@ func NewGitlabServiceWithTimeout(timeoutMins int) *Service {
 			rate.Every(constants.ImportRateLimitIntervalSeconds*time.Second),
 			constants.ImportRateLimitBurst,
 		),
+	}
+	return gs
+}
+
+// ServiceOption configures a Service built by NewServiceWithClient.
+type ServiceOption func(*Service)
+
+// WithExportTimeout overrides the export-polling timeout. A non-positive value is ignored.
+func WithExportTimeout(d time.Duration) ServiceOption {
+	return func(s *Service) {
+		if d > 0 {
+			s.exportTimeoutDuration = d
+		}
+	}
+}
+
+// WithExportCheckInterval overrides the delay between export-status polls.
+// A non-positive value is ignored. It is intended to keep tests fast.
+func WithExportCheckInterval(d time.Duration) ServiceOption {
+	return func(s *Service) {
+		if d > 0 {
+			s.exportCheckInterval = d
+		}
+	}
+}
+
+// WithRateLimiters overrides the download, export and import rate limiters.
+// Nil limiters are ignored, keeping the corresponding default.
+func WithRateLimiters(download, export, importer *rate.Limiter) ServiceOption {
+	return func(s *Service) {
+		if download != nil {
+			s.rateLimitDownloadAPI = download
+		}
+		if export != nil {
+			s.rateLimitExportAPI = export
+		}
+		if importer != nil {
+			s.rateLimitImportAPI = importer
+		}
+	}
+}
+
+// NewServiceWithClient builds a Service around an injected GitLabClient for
+// testing and advanced wiring. It reads no environment and creates no HTTP
+// client. SetToken/SetGitlabEndpoint would replace the injected client and
+// should not be called on services built this way.
+func NewServiceWithClient(client GitLabClient, opts ...ServiceOption) *Service {
+	gs := &Service{
+		client:                client,
+		gitlabAPIEndpoint:     constants.GitLabAPIEndpoint,
+		exportTimeoutDuration: constants.DefaultExportTimeoutMins * time.Minute,
+		rateLimitDownloadAPI: rate.NewLimiter(
+			rate.Every(constants.DownloadRateLimitIntervalSeconds*time.Second),
+			constants.DownloadRateLimitBurst,
+		),
+		rateLimitExportAPI: rate.NewLimiter(
+			rate.Every(constants.ExportRateLimitIntervalSeconds*time.Second),
+			constants.ExportRateLimitBurst,
+		),
+		rateLimitImportAPI: rate.NewLimiter(
+			rate.Every(constants.ImportRateLimitIntervalSeconds*time.Second),
+			constants.ImportRateLimitBurst,
+		),
+	}
+	for _, opt := range opts {
+		opt(gs)
 	}
 	return gs
 }

--- a/pkg/gitlab/project.go
+++ b/pkg/gitlab/project.go
@@ -126,8 +126,13 @@ loop:
 			log.Info("wait after gitlab to get the archive", "projectID", projectID)
 		}
 
-		// Sleep with context awareness
-		if err := s.sleepWithContext(timeoutCtx, projectID, constants.ExportCheckIntervalSeconds*time.Second); err != nil {
+		// Sleep with context awareness. The interval is configurable (defaulting to
+		// the documented constant) so tests can drive the polling loop quickly.
+		checkInterval := s.exportCheckInterval
+		if checkInterval <= 0 {
+			checkInterval = constants.ExportCheckIntervalSeconds * time.Second
+		}
+		if err := s.sleepWithContext(timeoutCtx, projectID, checkInterval); err != nil {
 			return err
 		}
 	}

--- a/pkg/gitlab/restore_test.go
+++ b/pkg/gitlab/restore_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sgaunet/gitlab-backup/pkg/gitlab/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go"
 )
 
@@ -244,4 +245,56 @@ func TestNewImportService_ZeroTimeoutFallsBackToDefault(t *testing.T) {
 	// Negative also falls back.
 	service = gitlab.NewImportService(mock, -1*time.Second)
 	require.NotNil(t, service, "Service should be created with negative timeout")
+}
+
+func TestNewImportServiceWithRateLimiters_Success(t *testing.T) {
+	mock := &mocks.ProjectImportExportServiceMock{
+		ImportFromFileFunc: func(_ context.Context, _ io.Reader, _ *gitlabapi.ImportFileOptions, _ ...gitlabapi.RequestOptionFunc) (*gitlabapi.ImportStatus, *gitlabapi.Response, error) {
+			return &gitlabapi.ImportStatus{ID: 7, ImportStatus: "scheduled"}, &gitlabapi.Response{}, nil
+		},
+		ImportStatusFunc: func(_ context.Context, _ any, _ ...gitlabapi.RequestOptionFunc) (*gitlabapi.ImportStatus, *gitlabapi.Response, error) {
+			return &gitlabapi.ImportStatus{ID: 7, ImportStatus: "finished"}, &gitlabapi.Response{}, nil
+		},
+	}
+
+	// An unlimited limiter keeps the test fast while exercising the custom-limiter constructor.
+	service := gitlab.NewImportServiceWithRateLimiters(mock, rate.NewLimiter(rate.Inf, 1), 10*time.Minute)
+	require.NotNil(t, service)
+
+	status, err := service.ImportProject(context.Background(), bytes.NewReader([]byte("data")), "ns", "proj")
+	require.NoError(t, err)
+	assert.Equal(t, "finished", status.ImportStatus)
+}
+
+func TestWaitForImport_StatusDeadlineIsTimeout(t *testing.T) {
+	// ImportStatus returns a context.DeadlineExceeded error, which the
+	// importTimeoutClassifier.isTimeout must classify as a timeout (mapping to
+	// ErrImportTimeout) rather than a generic status-check failure.
+	mock := &mocks.ProjectImportExportServiceMock{
+		ImportStatusFunc: func(_ context.Context, _ any, _ ...gitlabapi.RequestOptionFunc) (*gitlabapi.ImportStatus, *gitlabapi.Response, error) {
+			return nil, &gitlabapi.Response{}, context.DeadlineExceeded
+		},
+	}
+	service := gitlab.NewImportServiceWithRateLimiters(mock, rate.NewLimiter(rate.Inf, 1), 10*time.Minute)
+
+	_, err := service.WaitForImport(context.Background(), 123, 10*time.Minute)
+	require.Error(t, err)
+	require.ErrorIs(t, err, gitlab.ErrImportTimeout)
+}
+
+func TestImportProject_UnexpectedStatus(t *testing.T) {
+	mock := &mocks.ProjectImportExportServiceMock{
+		ImportFromFileFunc: func(_ context.Context, _ io.Reader, _ *gitlabapi.ImportFileOptions, _ ...gitlabapi.RequestOptionFunc) (*gitlabapi.ImportStatus, *gitlabapi.Response, error) {
+			return &gitlabapi.ImportStatus{ID: 9, ImportStatus: "scheduled"}, &gitlabapi.Response{}, nil
+		},
+		ImportStatusFunc: func(_ context.Context, _ any, _ ...gitlabapi.RequestOptionFunc) (*gitlabapi.ImportStatus, *gitlabapi.Response, error) {
+			return &gitlabapi.ImportStatus{ID: 9, ImportStatus: "some_bogus_state"}, &gitlabapi.Response{}, nil
+		},
+	}
+
+	service := gitlab.NewImportServiceWithRateLimiters(mock, rate.NewLimiter(rate.Inf, 1), 10*time.Minute)
+	_, err := service.ImportProject(context.Background(), bytes.NewReader([]byte("data")), "ns", "proj")
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, gitlab.ErrUnexpectedImportStatus)
 }

--- a/pkg/gitlab/service_blackbox_test.go
+++ b/pkg/gitlab/service_blackbox_test.go
@@ -1,0 +1,226 @@
+package gitlab_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sgaunet/gitlab-backup/pkg/gitlab"
+	"github.com/sgaunet/gitlab-backup/pkg/gitlab/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+	gitlabAPI "gitlab.com/gitlab-org/api/client-go"
+)
+
+// unlimited builds a service whose rate limiters never block, for fast tests.
+func unlimited() gitlab.ServiceOption {
+	return gitlab.WithRateLimiters(
+		rate.NewLimiter(rate.Inf, 1),
+		rate.NewLimiter(rate.Inf, 1),
+		rate.NewLimiter(rate.Inf, 1),
+	)
+}
+
+// importExportClient wires a GitLabClientMock that returns the given import/export mock.
+func importExportClient(ie *mocks.ProjectImportExportServiceMock) *mocks.GitLabClientMock {
+	return &mocks.GitLabClientMock{
+		ProjectImportExportFunc: func() gitlab.ProjectImportExportService { return ie },
+	}
+}
+
+func TestService_ExportProject_HappyPath(t *testing.T) {
+	var downloaded []byte
+	ie := &mocks.ProjectImportExportServiceMock{
+		ScheduleExportFunc: func(_ context.Context, _ any, _ *gitlabAPI.ScheduleExportOptions, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.Response, error) {
+			return &gitlabAPI.Response{Response: &http.Response{StatusCode: http.StatusAccepted}}, nil
+		},
+		ExportStatusFunc: func(_ context.Context, _ any, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.ExportStatus, *gitlabAPI.Response, error) {
+			return &gitlabAPI.ExportStatus{ExportStatus: "finished"}, &gitlabAPI.Response{}, nil
+		},
+		ExportDownloadStreamFunc: func(_ context.Context, _ any, w io.Writer, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.Response, error) {
+			_, _ = w.Write([]byte("archive-content"))
+			return &gitlabAPI.Response{}, nil
+		},
+	}
+
+	svc := gitlab.NewServiceWithClient(importExportClient(ie), unlimited())
+	archivePath := filepath.Join(t.TempDir(), "proj.tar.gz")
+
+	err := svc.ExportProject(context.Background(), &gitlab.Project{ID: 1, Name: "proj"}, archivePath)
+	require.NoError(t, err)
+
+	downloaded, err = os.ReadFile(archivePath)
+	require.NoError(t, err)
+	assert.Equal(t, "archive-content", string(downloaded))
+}
+
+func TestService_ExportProject_ArchivedShortCircuit(t *testing.T) {
+	ie := &mocks.ProjectImportExportServiceMock{} // no funcs -> would panic if called
+	svc := gitlab.NewServiceWithClient(importExportClient(ie), unlimited())
+
+	err := svc.ExportProject(context.Background(), &gitlab.Project{ID: 1, Name: "p", Archived: true}, "/does/not/matter")
+	require.NoError(t, err)
+	assert.Empty(t, ie.ScheduleExportCalls(), "archived project must not schedule an export")
+}
+
+func TestService_ExportProject_ScheduleError(t *testing.T) {
+	ie := &mocks.ProjectImportExportServiceMock{
+		ScheduleExportFunc: func(_ context.Context, _ any, _ *gitlabAPI.ScheduleExportOptions, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.Response, error) {
+			return nil, errors.New("schedule boom")
+		},
+	}
+	svc := gitlab.NewServiceWithClient(importExportClient(ie), unlimited())
+
+	err := svc.ExportProject(context.Background(), &gitlab.Project{ID: 1, Name: "p"}, filepath.Join(t.TempDir(), "a.tar.gz"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "export request")
+}
+
+func TestService_ExportProject_WaitTimeout(t *testing.T) {
+	ie := &mocks.ProjectImportExportServiceMock{
+		ScheduleExportFunc: func(_ context.Context, _ any, _ *gitlabAPI.ScheduleExportOptions, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.Response, error) {
+			return &gitlabAPI.Response{Response: &http.Response{StatusCode: http.StatusAccepted}}, nil
+		},
+		ExportStatusFunc: func(_ context.Context, _ any, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.ExportStatus, *gitlabAPI.Response, error) {
+			return &gitlabAPI.ExportStatus{ExportStatus: "started"}, &gitlabAPI.Response{}, nil
+		},
+	}
+	svc := gitlab.NewServiceWithClient(importExportClient(ie), unlimited(), gitlab.WithExportTimeout(time.Millisecond))
+
+	err := svc.ExportProject(context.Background(), &gitlab.Project{ID: 1, Name: "p"}, filepath.Join(t.TempDir(), "a.tar.gz"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestService_ExportProject_RetryExhaustion(t *testing.T) {
+	ie := &mocks.ProjectImportExportServiceMock{
+		ScheduleExportFunc: func(_ context.Context, _ any, _ *gitlabAPI.ScheduleExportOptions, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.Response, error) {
+			return &gitlabAPI.Response{Response: &http.Response{StatusCode: http.StatusAccepted}}, nil
+		},
+		ExportStatusFunc: func(_ context.Context, _ any, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.ExportStatus, *gitlabAPI.Response, error) {
+			// "none" is counted against MaxExportRetries.
+			return &gitlabAPI.ExportStatus{ExportStatus: "none"}, &gitlabAPI.Response{}, nil
+		},
+	}
+	svc := gitlab.NewServiceWithClient(
+		importExportClient(ie),
+		unlimited(),
+		gitlab.WithExportTimeout(time.Minute),
+		gitlab.WithExportCheckInterval(time.Millisecond),
+	)
+
+	err := svc.ExportProject(context.Background(), &gitlab.Project{ID: 1, Name: "p"}, filepath.Join(t.TempDir(), "a.tar.gz"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gitlab.ErrExportTimeout)
+}
+
+func TestService_ExportProject_DownloadError(t *testing.T) {
+	ie := &mocks.ProjectImportExportServiceMock{
+		ScheduleExportFunc: func(_ context.Context, _ any, _ *gitlabAPI.ScheduleExportOptions, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.Response, error) {
+			return &gitlabAPI.Response{Response: &http.Response{StatusCode: http.StatusAccepted}}, nil
+		},
+		ExportStatusFunc: func(_ context.Context, _ any, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.ExportStatus, *gitlabAPI.Response, error) {
+			return &gitlabAPI.ExportStatus{ExportStatus: "finished"}, &gitlabAPI.Response{}, nil
+		},
+		ExportDownloadStreamFunc: func(_ context.Context, _ any, _ io.Writer, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.Response, error) {
+			return &gitlabAPI.Response{}, errors.New("download boom")
+		},
+	}
+	svc := gitlab.NewServiceWithClient(importExportClient(ie), unlimited())
+	archivePath := filepath.Join(t.TempDir(), "a.tar.gz")
+
+	err := svc.ExportProject(context.Background(), &gitlab.Project{ID: 1, Name: "p"}, archivePath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "download export")
+
+	// The final archive must not exist (only a .tmp was created, never renamed).
+	_, statErr := os.Stat(archivePath)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestService_GetProjectsOfGroup(t *testing.T) {
+	groups := &mocks.GroupsServiceMock{
+		ListSubGroupsFunc: func(_ context.Context, gid any, _ *gitlabAPI.ListSubGroupsOptions, _ ...gitlabAPI.RequestOptionFunc) ([]*gitlabAPI.Group, *gitlabAPI.Response, error) {
+			if gid == int64(100) {
+				return []*gitlabAPI.Group{{ID: 200, Name: "sub"}}, &gitlabAPI.Response{NextPage: 0}, nil
+			}
+			return nil, &gitlabAPI.Response{NextPage: 0}, nil
+		},
+		ListGroupProjectsFunc: func(_ context.Context, gid any, _ *gitlabAPI.ListGroupProjectsOptions, _ ...gitlabAPI.RequestOptionFunc) ([]*gitlabAPI.Project, *gitlabAPI.Response, error) {
+			switch gid {
+			case int64(200):
+				return []*gitlabAPI.Project{{ID: 2, Name: "sub-proj"}}, &gitlabAPI.Response{NextPage: 0}, nil
+			case int64(100):
+				return []*gitlabAPI.Project{
+					{ID: 1, Name: "main"},
+					{ID: 3, Name: "arch", Archived: true},
+				}, &gitlabAPI.Response{NextPage: 0}, nil
+			default:
+				return nil, &gitlabAPI.Response{NextPage: 0}, nil
+			}
+		},
+	}
+	client := &mocks.GitLabClientMock{
+		GroupsFunc: func() gitlab.GroupsService { return groups },
+	}
+	svc := gitlab.NewServiceWithClient(client, unlimited())
+
+	projects, err := svc.GetProjectsOfGroup(context.Background(), 100)
+	require.NoError(t, err)
+
+	// Archived project 3 filtered out; projects from subgroup and main group aggregated.
+	require.Len(t, projects, 2)
+	ids := map[int64]bool{}
+	for _, p := range projects {
+		ids[p.ID] = true
+	}
+	assert.True(t, ids[1], "main project should be present")
+	assert.True(t, ids[2], "subgroup project should be present")
+	assert.False(t, ids[3], "archived project must be filtered out")
+}
+
+func TestService_Getters(t *testing.T) {
+	svc := gitlab.NewServiceWithClient(&mocks.GitLabClientMock{}, unlimited())
+
+	svc.SetGitlabEndpoint("https://gitlab.example.com/api/v4")
+	assert.Equal(t, "https://gitlab.example.com/api/v4", svc.GitlabEndpoint())
+
+	assert.NotNil(t, svc.Client(), "Client should return the injected client")
+	assert.NotNil(t, svc.RateLimitImportAPI(), "import rate limiter should be set")
+}
+
+func TestService_GetProject(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		projects := &mocks.ProjectsServiceMock{
+			GetProjectFunc: func(_ context.Context, _ any, _ *gitlabAPI.GetProjectOptions, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.Project, *gitlabAPI.Response, error) {
+				return &gitlabAPI.Project{ID: 42, Name: "answer"}, &gitlabAPI.Response{}, nil
+			},
+		}
+		client := &mocks.GitLabClientMock{ProjectsFunc: func() gitlab.ProjectsService { return projects }}
+		svc := gitlab.NewServiceWithClient(client, unlimited())
+
+		p, err := svc.GetProject(context.Background(), 42)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), p.ID)
+		assert.Equal(t, "answer", p.Name)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		projects := &mocks.ProjectsServiceMock{
+			GetProjectFunc: func(_ context.Context, _ any, _ *gitlabAPI.GetProjectOptions, _ ...gitlabAPI.RequestOptionFunc) (*gitlabAPI.Project, *gitlabAPI.Response, error) {
+				return nil, &gitlabAPI.Response{}, errors.New("not found")
+			},
+		}
+		client := &mocks.GitLabClientMock{ProjectsFunc: func() gitlab.ProjectsService { return projects }}
+		svc := gitlab.NewServiceWithClient(client, unlimited())
+
+		_, err := svc.GetProject(context.Background(), 42)
+		require.Error(t, err)
+	})
+}

--- a/pkg/gitlab/service_interface.go
+++ b/pkg/gitlab/service_interface.go
@@ -1,8 +1,32 @@
 package gitlab
 
-import "golang.org/x/time/rate"
+import (
+	"context"
+
+	"golang.org/x/time/rate"
+)
 
 //go:generate go tool github.com/matryer/moq -out mocks/service.go -pkg mocks . GitLabService
+//go:generate go tool github.com/matryer/moq -out mocks/backup_service.go -pkg mocks . BackupService
+
+// BackupService is the GitLab surface the backup application layer (pkg/app)
+// depends on. It exists so the application can be driven with a mock in
+// black-box tests instead of a live GitLab connection. *Service satisfies it.
+type BackupService interface {
+	// SetToken sets the GitLab API token used for authentication.
+	SetToken(token string)
+	// SetGitlabEndpoint sets the GitLab API endpoint.
+	SetGitlabEndpoint(endpoint string)
+	// GetProject returns the project identified by projectID.
+	GetProject(ctx context.Context, projectID int64) (Project, error)
+	// GetProjectsOfGroup returns every non-archived project of the group and its subgroups.
+	GetProjectsOfGroup(ctx context.Context, groupID int64) ([]Project, error)
+	// ExportProject exports project to archiveFilePath.
+	ExportProject(ctx context.Context, project *Project, archiveFilePath string) error
+}
+
+// Compile-time guarantee that *Service satisfies BackupService.
+var _ BackupService = (*Service)(nil)
 
 // GitLabService defines the GitLab service operations needed for restore workflows.
 // This interface enables testing of the restore orchestrator without requiring a

--- a/pkg/storage/localstorage/localstorage_test.go
+++ b/pkg/storage/localstorage/localstorage_test.go
@@ -1,21 +1,19 @@
-package localstorage
+package localstorage_test
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/sgaunet/gitlab-backup/pkg/storage/localstorage"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSaveFile(t *testing.T) {
 	// Create a temporary directory for testing
-	tempDir, err := os.MkdirTemp("/tmp", "localstorage_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Create a temporary source file
 	srcFile, err := os.CreateTemp(tempDir, "source")
@@ -32,7 +30,7 @@ func TestSaveFile(t *testing.T) {
 	srcFile.Close()
 
 	// Initialize LocalStorage
-	storage := NewLocalStorage(tempDir)
+	storage := localstorage.NewLocalStorage(tempDir)
 
 	// Define the destination filename
 	dstFilename := "dstFile"
@@ -56,28 +54,24 @@ func TestSaveFile(t *testing.T) {
 }
 
 func TestSaveFileWithEmptySource(t *testing.T) {
-	tempDir, err := os.MkdirTemp("/tmp", "localstorage_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	// Initialize LocalStorage
-	storage := NewLocalStorage(tempDir)
+	storage := localstorage.NewLocalStorage(tempDir)
 
 	dstFilename := "dstFile"
 
 	// Call SaveFile
-	err = storage.SaveFile(context.Background(), "file-that-does-not-exist", dstFilename)
+	err := storage.SaveFile(context.Background(), "file-that-does-not-exist", dstFilename)
 	require.Error(t, err)
 }
 
 func TestSaveFileWithWrontDestinationFolder(t *testing.T) {
 	// Initialize LocalStorage
-	storage := NewLocalStorage("/tmp-does-not-exist")
+	storage := localstorage.NewLocalStorage("/tmp-does-not-exist")
 	dstFilename := "dstFile"
 
-	// Create temp file in /tmp
-	srcFile, err := os.CreateTemp("/tmp", "source")
+	// Create temp file
+	srcFile, err := os.CreateTemp(t.TempDir(), "source")
 	require.NoError(t, err)
 	defer os.Remove(srcFile.Name())
 
@@ -86,12 +80,32 @@ func TestSaveFileWithWrontDestinationFolder(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestSaveFile_LargeFile copies a source larger than the copy buffer so the
+// multi-iteration copy loop and the EOF-break path are exercised.
+func TestSaveFile_LargeFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Well over the 32KB copy buffer to force several read/write iterations.
+	content := make([]byte, 256*1024)
+	for i := range content {
+		content[i] = byte(i % 251)
+	}
+
+	srcPath := filepath.Join(tempDir, "large-source")
+	require.NoError(t, os.WriteFile(srcPath, content, 0o600))
+
+	storage := localstorage.NewLocalStorage(tempDir)
+	dstFilename := "large-dst"
+	require.NoError(t, storage.SaveFile(context.Background(), srcPath, dstFilename))
+
+	got, err := os.ReadFile(filepath.Join(tempDir, dstFilename))
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(content, got), "copied content should match source")
+}
+
 // TestSaveFile_ContextCancellation verifies that SaveFile respects context cancellation.
 func TestSaveFile_ContextCancellation(t *testing.T) {
-	// Create a temporary directory for testing
-	tempDir, err := os.MkdirTemp("/tmp", "localstorage_test_cancel")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Create a temporary source file with some content
 	srcFile, err := os.CreateTemp(tempDir, "source_large")
@@ -108,7 +122,7 @@ func TestSaveFile_ContextCancellation(t *testing.T) {
 	srcFile.Close()
 
 	// Initialize LocalStorage
-	storage := NewLocalStorage(tempDir)
+	storage := localstorage.NewLocalStorage(tempDir)
 
 	// Create a cancelled context
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
- add black-box suites for config restore validation, app backup
  orchestration, restore success path, and gitlab service/wrapper flows
- add additive test seams: gitlab.BackupService + app.NewAppWithService,
  gitlab.NewServiceWithClient with options, restore.NewOrchestratorWithProgress
- convert localstorage and restore progress/orchestrator tests to black-box
- raise coverage: config 67->94%, app 37->89%, restore 77->88%, gitlab 48->88%

Closes #370